### PR TITLE
Add HTTPS ALB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ before_script:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 script:
-  - npm test -- --coverage
+  - npm run coverage
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ npm run watch
 Before submitting a PR, make sure to run all of the following:
 ```shell
 npm run build
-npm test
+npm run coverage && open coverage/lcov-report/index.html
 npm run lint
 npm run format
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,24 @@ Creates an Aspect that will apply stack level tags to all stacks in the applicat
 Example usage:
 ```typescript
 import cdk = require('@aws-cdk/core');
-import { StackTags } from 'ndlib-cdk';
+import { StackTags } from '@ndlib/ndlib-cdk';
 const app = new cdk.App();
 app.node.applyAspect(new StackTags());
+```
+
+## HTTPS Application Load Balancer
+Creates a common construction of an ALB that will redirect all traffic from HTTP to HTTPS, and will by default respond with a 404 until additional listener rules are added. This can be used within a single stack that routes to multiple services in that stack, or it can be created in a parent stack where one or more child stacks then attach new services to the ALB.
+
+Example usage:
+```typescript
+import cdk = require('@aws-cdk/core');
+import ec2 = require('@aws-cdk/aws-ec2');
+import { HttpsAlb } from '@ndlib/ndlib-cdk';
+const stack = new cdk.Stack();
+const vpc = new ec2.Vpc(stack, 'Vpc');
+const alb = new HttpsAlb(stack, 'PublicLoadBalancer', {
+  certificateArns: ['MyCertificateArn'],
+  internetFacing: true,
+  vpc,
+});
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,219 @@
         "source-map-support": "^0.5.13"
       }
     },
+    "@aws-cdk/assets": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.9.0.tgz",
+      "integrity": "sha512-3FC1BCpTJaHRbRuBQs83qPoX3kFBG7t7qWuEAX2W9XjQDSfbutqCMsheSjfcoX5FXuMNhZEG6PXawp2dLJGjvQ==",
+      "requires": {
+        "@aws-cdk/core": "^1.9.0",
+        "@aws-cdk/cx-api": "^1.9.0",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "@aws-cdk/aws-certificatemanager": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.9.0.tgz",
+      "integrity": "sha512-HyZS5I2zb8mcLrzcveFGqdsLynErOeAvAYt+WD6r8R8qjtt53AsIOVVvi1RNFbSSSUPoqxadyuy/n22Va44+sA==",
+      "requires": {
+        "@aws-cdk/aws-cloudformation": "^1.9.0",
+        "@aws-cdk/aws-iam": "^1.9.0",
+        "@aws-cdk/aws-lambda": "^1.9.0",
+        "@aws-cdk/aws-route53": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-cloudformation": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.9.0.tgz",
+      "integrity": "sha512-g4EIZkPjakN+ipOSzbt73iRUCEHLQwKiLdIb9zS3520aBgiAEOZ6NcDkq0/740hVItjOiRr8+J0oCtRdpm0sGA==",
+      "requires": {
+        "@aws-cdk/aws-iam": "^1.9.0",
+        "@aws-cdk/aws-lambda": "^1.9.0",
+        "@aws-cdk/aws-sns": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-cloudwatch": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.9.0.tgz",
+      "integrity": "sha512-+Bl4CHN+Ct30qcbgMNScJ7P6aM2ZUh2CXhpbsrinlxj7s2ukp1YzXoKHX6GDUx3ATvHiAwZogIwJEOMuf7Nkjw==",
+      "requires": {
+        "@aws-cdk/aws-iam": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-ec2": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.9.0.tgz",
+      "integrity": "sha512-6noSzLDisNrp4Ad4k+BWiCxLWBAe1skGtzs0TsvxWxXIseXvLmRnlgXqyslmTCDHW9v0chTLdKgQXlTq4Zj8EA==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "^1.9.0",
+        "@aws-cdk/aws-iam": "^1.9.0",
+        "@aws-cdk/aws-ssm": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0",
+        "@aws-cdk/cx-api": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-elasticloadbalancingv2": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.9.0.tgz",
+      "integrity": "sha512-9ocZAQmxyc1OfnH330vFWWYOuVbdBdd/vitBcF4Lz3P8hYNagUs+ZEW29CzGOHo+WnLX0no4I2sxnfOBvLc5dg==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "^1.9.0",
+        "@aws-cdk/aws-cloudwatch": "^1.9.0",
+        "@aws-cdk/aws-ec2": "^1.9.0",
+        "@aws-cdk/aws-iam": "^1.9.0",
+        "@aws-cdk/aws-lambda": "^1.9.0",
+        "@aws-cdk/aws-s3": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-events": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.9.0.tgz",
+      "integrity": "sha512-xIZQDkwtj8KyzDhC2Lcjn6Ac7d4E//W7Lfl7m/iXAsPrclkZBODPJhtzytX7PGM++hJy6hKspbtNxnGGbDflkg==",
+      "requires": {
+        "@aws-cdk/aws-iam": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-iam": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.9.0.tgz",
+      "integrity": "sha512-wCnSgdM4Jxbzzjypng7z+vzH+uAHFBZrBH56ck1xG7rin+wJZFdC4vaAMD39nVf5V1EUEAuwQjK0F33QuT44iQ==",
+      "requires": {
+        "@aws-cdk/core": "^1.9.0",
+        "@aws-cdk/region-info": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-kms": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.9.0.tgz",
+      "integrity": "sha512-U4ucUl7zT5jML/FkWNd74lVqzi3cC9tkt7j7pORWUp3ssspQ5G8QcwuDtFxGBarsx6gI9QjwcqyoHPHrXotlHQ==",
+      "requires": {
+        "@aws-cdk/aws-iam": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-lambda": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.9.0.tgz",
+      "integrity": "sha512-Daf9Sy/Xr2NoXnHf1xn/rWdZRd6rN3RgBza1g2kVX5/D3QavHYSsBMEsbgb9EdrbakBpDMPyO7Q8v1SWF5+slQ==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "^1.9.0",
+        "@aws-cdk/aws-ec2": "^1.9.0",
+        "@aws-cdk/aws-events": "^1.9.0",
+        "@aws-cdk/aws-iam": "^1.9.0",
+        "@aws-cdk/aws-logs": "^1.9.0",
+        "@aws-cdk/aws-s3": "^1.9.0",
+        "@aws-cdk/aws-s3-assets": "^1.9.0",
+        "@aws-cdk/aws-sqs": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0",
+        "@aws-cdk/cx-api": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-logs": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.9.0.tgz",
+      "integrity": "sha512-MkFfw1LsMv+IMN455ADbRBsogCH8gtU41l201RifNfDT2TZOQUaW7VHtODIu34ZxWR+Qzd04cAcHXTJ0giLA3A==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "^1.9.0",
+        "@aws-cdk/aws-iam": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-route53": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.9.0.tgz",
+      "integrity": "sha512-+qhPM1UCht9674/xx1zLyjA4sXy1lEG/14W47VyC3+u9nLydrvqHFlVO470q05mcRP04C4RhfaVumFQpO0D7yQ==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "^1.9.0",
+        "@aws-cdk/aws-logs": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0",
+        "@aws-cdk/cx-api": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-s3": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.9.0.tgz",
+      "integrity": "sha512-DeOlW2x0kqgVBuZa0Conmt5+zWFvfw6xqQbsU81+G9efgI8cBOVHpCyTYknrhgECbM/2pB+qERsaLyTFqQ5+qw==",
+      "requires": {
+        "@aws-cdk/aws-events": "^1.9.0",
+        "@aws-cdk/aws-iam": "^1.9.0",
+        "@aws-cdk/aws-kms": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-s3-assets": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.9.0.tgz",
+      "integrity": "sha512-fuguSw8lxNtOK9agJ7He8ulVRIGASnUhltEWzJiZqMc/72X3D9MTJuLnwEZwKaKm7qlgy8wfCHXZ/e0FxWasRw==",
+      "requires": {
+        "@aws-cdk/assets": "^1.9.0",
+        "@aws-cdk/aws-iam": "^1.9.0",
+        "@aws-cdk/aws-s3": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0",
+        "@aws-cdk/cx-api": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-sns": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.9.0.tgz",
+      "integrity": "sha512-c75L/yNJ3QSl16+LvMzuK61eSXSltM0mu4xG521ZBCnasc6l7Ioqt0FaAHqFEqEH+DXjio9r3h1pviD4DyU9lQ==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "^1.9.0",
+        "@aws-cdk/aws-events": "^1.9.0",
+        "@aws-cdk/aws-iam": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-sqs": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.9.0.tgz",
+      "integrity": "sha512-AFgaAGPsXuYfBNRg5ckXKetYaM9hDqxyNL8H/dXOyqOlfuQpw71piI0ksVGyhkmQQ61fHZojp/zzEP4NurQjmw==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "^1.9.0",
+        "@aws-cdk/aws-iam": "^1.9.0",
+        "@aws-cdk/aws-kms": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0"
+      }
+    },
+    "@aws-cdk/aws-ssm": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.9.0.tgz",
+      "integrity": "sha512-9pCakaSkAMn/KYNZuBOSthtysmcb62cCXv9XC06nkSHLpnM4qytngTcCFhTNn9OFzVGVy8i69cubui3hGerJ1Q==",
+      "requires": {
+        "@aws-cdk/aws-iam": "^1.9.0",
+        "@aws-cdk/core": "^1.9.0",
+        "@aws-cdk/cx-api": "^1.9.0"
+      }
+    },
     "@aws-cdk/cfnspec": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.9.0.tgz",
@@ -88,6 +301,11 @@
           "bundled": true
         }
       }
+    },
+    "@aws-cdk/region-info": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.9.0.tgz",
+      "integrity": "sha512-GX7oZRCgLx7Y0UV3BR8D1yFY7ikNAKBcegWoLWEFdDBZ7jAUiwYUrPfxEqz4l1bndtSBAptAhAmLL3Dshh9/4Q=="
     },
     "@babel/code-frame": {
       "version": "7.5.5",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "ndlib-cdk",
+  "name": "@ndlib/ndlib-cdk",
   "version": "1.0.2",
   "description": "Reusable CDK modules used within Hesburgh Libraries of Notre Dame",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
     "test": "jest --config jestconfig.json",
+    "coverage": "jest --config jestconfig.json --coverage",
     "build": "tsc",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
     "lint": "tslint -p tsconfig.json",
@@ -49,6 +50,7 @@
     "lib/**/*"
   ],
   "dependencies": {
+    "@aws-cdk/aws-elasticloadbalancingv2": "^1.9.0",
     "@aws-cdk/core": "^1.9.0"
   }
 }

--- a/src/https-alb.ts
+++ b/src/https-alb.ts
@@ -1,0 +1,79 @@
+import elbv2 = require('@aws-cdk/aws-elasticloadbalancingv2');
+import cdk = require('@aws-cdk/core');
+
+export interface IHttpsAlbProps extends elbv2.ApplicationLoadBalancerProps {
+  /**
+   * The certificate used to terminate SSL at the ALB
+   */
+  readonly certificateArns: string[];
+}
+
+export class HttpsAlb extends elbv2.ApplicationLoadBalancer {
+  /**
+   * This is the default SSL listener. Attach additional rules
+   * to this listener using new elbv2.ApplicationListenerRule.
+   */
+  public readonly defaultListener: elbv2.ApplicationListener;
+
+  /**
+   * Defines a public Application Load Balancer with an SSL listener that 404's by default, 
+   * and redirects all http traffic to https.
+   * 
+   * @param scope The scope in which to define this construct
+   * @param id The scoped construct ID. Must be unique amongst siblings. If
+   * the ID includes a path separator (`/`), then it will be replaced by double
+   * dash `--`.
+   * @param props IHttpsAlbProps properties.
+   */
+  constructor(scope: cdk.Construct, id: string, props: IHttpsAlbProps) {
+    super(scope, id, props);
+
+    this.addHttpRedirect();
+
+    // Add https listener that by default 404s until other rules are added. 
+    this.defaultListener = this.addListener('HttpsListener', {
+      certificateArns: props.certificateArns,
+      open: true,
+      port: 443,
+      protocol: elbv2.ApplicationProtocol.HTTPS,
+      sslPolicy: elbv2.SslPolicy.RECOMMENDED,
+    });
+    this.defaultListener.addFixedResponse('Default404', {
+      statusCode: '404'
+    });
+
+    // Adding an output of the dns name for convenience when looking at this
+    // in the console/cli.
+    const dnsNameOutput = new cdk.CfnOutput(scope, 'PublicLoadBalancerDNSName', { 
+      description: 'The DNS name of the load balancer',
+      value: this.loadBalancerDnsName,
+    });
+  }
+
+  private addHttpRedirect() {
+    // Add a listener to redirect http to https
+    const httpListener = this.addListener('HttpListener', {
+      open: true,
+      port: 80,
+      protocol: elbv2.ApplicationProtocol.HTTP,
+    });
+    // Ideally this can be removed, and the CfnListener below can be rewritten once
+    // cdk adds support for adding a redirect rule as the default. 
+    // See https://github.com/aws/aws-cdk/issues/2563.
+    httpListener.addFixedResponse('Default404', {
+      statusCode: '404'
+    });
+    const cfnHttpListener = httpListener.node.defaultChild as elbv2.CfnListener;
+    cfnHttpListener.defaultActions = [{
+      redirectConfig: {
+        host: "#{host}",
+        path: "/#{path}",
+        port: "443",
+        protocol: "HTTPS",
+        query: "#{query}",
+        statusCode: "HTTP_301" // Should probably use 308 here at this point? ALB doesn't support this.
+      },
+      type: "redirect"
+    }];
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./stack-tags";
+export * from "./https-alb";

--- a/tests/https-alb.test.ts
+++ b/tests/https-alb.test.ts
@@ -1,0 +1,110 @@
+import { expect, haveResource } from '@aws-cdk/assert';
+import ec2 = require('@aws-cdk/aws-ec2');
+import { Stack } from "@aws-cdk/core";
+import { HttpsAlb } from '../src/index';
+
+test('HttpsAlb is internet facing', () => {
+  const stack = new Stack();
+  const vpc = new ec2.Vpc(stack, 'Stack');
+  const alb = new HttpsAlb(stack, 'PublicLoadBalancer', {
+    certificateArns: [''],
+    internetFacing: true,
+    vpc,
+  });
+  expect(stack).to(haveResource('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+    Scheme: "internet-facing",
+  }));
+});
+
+test('HttpsAlb creates a SecurityGroup that allows inbound from anywhere on http and https', () => {
+  const stack = new Stack();
+  const vpc = new ec2.Vpc(stack, 'testVpc');
+  const alb = new HttpsAlb(stack, 'testPublicLoadBalancer', {
+    certificateArns: ['testCertificateArn'],
+    internetFacing: true,
+    vpc,
+  });
+  expect(stack).to(haveResource('AWS::EC2::SecurityGroup', {
+    "GroupDescription": "Automatically created Security Group for ELB testPublicLoadBalancer",
+    "SecurityGroupIngress": [
+      {
+        "CidrIp": "0.0.0.0/0",
+        "Description": "Allow from anyone on port 80",
+        "FromPort": 80,
+        "IpProtocol": "tcp",
+        "ToPort": 80
+      },
+      {
+        "CidrIp": "0.0.0.0/0",
+        "Description": "Allow from anyone on port 443",
+        "FromPort": 443,
+        "IpProtocol": "tcp",
+        "ToPort": 443
+      }
+    ],
+    "VpcId": {
+      "Ref": "testVpcCB3A84F3"
+    }
+  }));
+});
+
+test('HttpsAlb adds a redirect from http to https that does not rewrite anything', () => {
+  const stack = new Stack();
+  const vpc = new ec2.Vpc(stack, 'testVpc');
+  const alb = new HttpsAlb(stack, 'testPublicLoadBalancer', {
+    certificateArns: ['testCertificateArn'],
+    internetFacing: true,
+    vpc,
+  });
+  expect(stack).to(haveResource('AWS::ElasticLoadBalancingV2::Listener', {
+    "DefaultActions": [
+      {
+        "RedirectConfig": {
+          "Host": "#{host}",
+          "Path": "/#{path}",
+          "Port": "443",
+          "Protocol": "HTTPS",
+          "Query": "#{query}",
+          "StatusCode": "HTTP_301"
+        },
+        "Type": "redirect"
+      }
+    ],
+    "LoadBalancerArn": {
+      "Ref": "testPublicLoadBalancer86E32544"
+    },
+    "Port": 80,
+    "Protocol": "HTTP"
+  }));
+});
+
+test('HttpsAlb adds a https listener with a default action to 404', () => {
+  const stack = new Stack();
+  const vpc = new ec2.Vpc(stack, 'testVpc');
+  const alb = new HttpsAlb(stack, 'testPublicLoadBalancer', {
+    certificateArns: ['testCertificateArn'],
+    internetFacing: true,
+    vpc,
+  });
+  expect(stack).to(haveResource('AWS::ElasticLoadBalancingV2::Listener', {
+    "Certificates": [
+      {
+        "CertificateArn": "testCertificateArn"
+      }
+    ],
+    "DefaultActions": [
+      {
+        "FixedResponseConfig": {
+          "StatusCode": "404"
+        },
+        "Type": "fixed-response"
+      }
+    ],
+    "LoadBalancerArn": {
+      "Ref": "testPublicLoadBalancer86E32544"
+    },
+    "Port": 443,
+    "Protocol": "HTTPS",
+    "SslPolicy": "ELBSecurityPolicy-2016-08"
+  }));
+});


### PR DESCRIPTION
This adds a common way to construct an ALB that will redirect all traffic from http to https, and will by default respond with a 404 until additional listener rules are added. This can be used within a single stack that routes to multiple services in that stack, or it can be created in a parent stack where one or more child stacks then attach new services to the ALB.

Additional changes:
* Changed the package to be within the @ndlib organization. Will likely still only bump patch since there are no downstream apps yet.
* Added additional coverage to the stack-tags aspect to hit the else condition (when the node is not a stack)
* Added coverage command to npm package to make it easier to run and added a note about running it before PR in CONTRIBUTING