### PR TITLE
Add Slack Approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,25 @@ const notifications = new PipelineNotifications(stack, 'TestPipelineNotification
   receivers: 'me@myhost.com'
 });
 ```
+
+## CodePipeline Slack Approval
+
+Attaches a [Slack Approval Bot](https://github.com/ndlib/codepipeline-approvals/blob/master/slack_approval.md) to a CodePipeline's approval SNS Topic. 
+
+Note: This assumes that you've already deployed an [approval lambda](https://github.com/ndlib/codepipeline-approvals/blob/master/slack_approval.md#deploy-the-approval-lambda) and a [notifier](https://github.com/ndlib/codepipeline-approvals/blob/master/slack_approval.md#deploy-the-notifier-lambda) for the channel you want to push messages to.
+
+Example usage:
+
+```typescript
+import cdk = require('@aws-cdk/core');
+import { Pipeline } from '@aws-cdk/aws-codepipeline';
+import { Topic } from '@aws-cdk/aws-sns';
+import { SlackApproval } from '@ndlib/ndlib-cdk';
+const stack = new cdk.Stack();
+const approvalTopic = new Topic(this, 'ApprovalTopic');
+const pipeline = Pipeline(stack, { ... });
+const slackApproval = new SlackApproval(this, 'SlackApproval', {
+  approvalTopic,
+  notifyStackName: 'slack-deployment-channel-notifier',
+});
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from './stack-tags';
 export * from './https-alb';
 export * from './archive-bucket';
 export * from './pipeline-notifications';
+export * from './slack-approval';

--- a/src/slack-approval.ts
+++ b/src/slack-approval.ts
@@ -1,0 +1,42 @@
+import { CfnPermission } from '@aws-cdk/aws-lambda';
+import { Subscription, SubscriptionProtocol, Topic } from '@aws-cdk/aws-sns';
+import { Construct, Fn } from '@aws-cdk/core';
+
+export interface ISlackApprovalProps {
+  /**
+   * The SNS topic associated with the approval action that you would like to subscribe the bot to
+   *
+   * @default - No description.
+   */
+  readonly approvalTopic: Topic;
+  /**
+   * The stack that manages the channel notifier
+   *
+   * @default - No description.
+   * @see https://github.com/ndlib/codepipeline-approvals/blob/master/slack_approval.md#deploy-the-notifier-lambda
+   */
+  readonly notifyStackName: string;
+}
+
+/**
+ * Connects the approval topic from a pipeline with a Slack approval bot
+ * @see https://github.com/ndlib/codepipeline-approvals/blob/master/slack_approval.md#slack-approval-bot
+ */
+export class SlackApproval extends Construct {
+  constructor(scope: Construct, id: string, props: ISlackApprovalProps) {
+    super(scope, id);
+    const importedNotifyLambdaArn = Fn.importValue(`${props.notifyStackName}:LambdaArn`);
+
+    new Subscription(this, 'NotifyLambdaSNSSubscription', {
+      endpoint: importedNotifyLambdaArn,
+      protocol: SubscriptionProtocol.LAMBDA,
+      topic: props.approvalTopic,
+    });
+    new CfnPermission(this, 'NotifyLambdaSNSPermission', {
+      action: 'lambda:InvokeFunction',
+      principal: 'sns.amazonaws.com',
+      sourceArn: props.approvalTopic.topicArn,
+      functionName: importedNotifyLambdaArn,
+    });
+  }
+}

--- a/tests/slack-approval.test.ts
+++ b/tests/slack-approval.test.ts
@@ -1,0 +1,35 @@
+import { expect, haveResourceLike } from '@aws-cdk/assert';
+import { Topic } from '@aws-cdk/aws-sns';
+import { Stack } from "@aws-cdk/core";
+import { SlackApproval } from '../src/index';
+
+test('Subscribes the imported notifier lambda to the approval topic', () => {
+  const stack = new Stack();
+  const approvalTopic = new Topic(stack, 'TestApprovalTopic');
+  new SlackApproval(stack, 'TestPipelineSlackApproval', { approvalTopic, notifyStackName: 'TestNotifyStackName'});
+  expect(stack).to(haveResourceLike('AWS::SNS::Subscription', {
+    "Protocol": "lambda",
+    "TopicArn": {
+      "Ref": "TestApprovalTopic34C9492C",
+    },
+    "Endpoint": {
+      "Fn::ImportValue": "TestNotifyStackName:LambdaArn"
+    }
+  }));
+});
+
+test('Gives the approval topic permission to invoke the imported notifier lambda', () => {
+  const stack = new Stack();
+  const approvalTopic = new Topic(stack, 'TestApprovalTopic');
+  new SlackApproval(stack, 'TestPipelineSlackApproval', { approvalTopic, notifyStackName: 'TestNotifyStackName'});
+  expect(stack).to(haveResourceLike('AWS::Lambda::Permission', {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+      "Fn::ImportValue": "TestNotifyStackName:LambdaArn"
+    },
+    "Principal": "sns.amazonaws.com",
+    "SourceArn": {
+      "Ref": "TestApprovalTopic34C9492C"
+    }
+  }));
+});


### PR DESCRIPTION
Adds a way to connect a pipeline's approval SNS topic to our Slack approval bot.

Fixes #15