### PR TITLE
Fix an issue with applying tags on a NestedStack construct.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,6 +135,21 @@
         "@aws-cdk/aws-lambda": "1.18.0",
         "@aws-cdk/aws-route53": "1.18.0",
         "@aws-cdk/core": "1.18.0"
+      },
+      "dependencies": {
+        "@aws-cdk/aws-cloudformation": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.18.0.tgz",
+          "integrity": "sha512-cCkz9pZwimlQMlToWwM0r9hlRY1TLi+7LNhbpiKclKbJx6qM/Hbw366CZf7JnKKeM85k/8eEGi54S85fK48fSQ==",
+          "requires": {
+            "@aws-cdk/aws-iam": "1.18.0",
+            "@aws-cdk/aws-lambda": "1.18.0",
+            "@aws-cdk/aws-s3": "1.18.0",
+            "@aws-cdk/aws-sns": "1.18.0",
+            "@aws-cdk/core": "1.18.0",
+            "@aws-cdk/cx-api": "1.18.0"
+          }
+        }
       }
     },
     "@aws-cdk/aws-cloudformation": {
@@ -249,6 +264,21 @@
         "@aws-cdk/aws-s3": "1.18.0",
         "@aws-cdk/core": "1.18.0",
         "@aws-cdk/cx-api": "1.18.0"
+      },
+      "dependencies": {
+        "@aws-cdk/aws-cloudformation": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.18.0.tgz",
+          "integrity": "sha512-cCkz9pZwimlQMlToWwM0r9hlRY1TLi+7LNhbpiKclKbJx6qM/Hbw366CZf7JnKKeM85k/8eEGi54S85fK48fSQ==",
+          "requires": {
+            "@aws-cdk/aws-iam": "1.18.0",
+            "@aws-cdk/aws-lambda": "1.18.0",
+            "@aws-cdk/aws-s3": "1.18.0",
+            "@aws-cdk/aws-sns": "1.18.0",
+            "@aws-cdk/core": "1.18.0",
+            "@aws-cdk/cx-api": "1.18.0"
+          }
+        }
       }
     },
     "@aws-cdk/aws-ecs": {
@@ -279,6 +309,21 @@
         "@aws-cdk/aws-ssm": "1.18.0",
         "@aws-cdk/core": "1.18.0",
         "@aws-cdk/cx-api": "1.18.0"
+      },
+      "dependencies": {
+        "@aws-cdk/aws-cloudformation": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.18.0.tgz",
+          "integrity": "sha512-cCkz9pZwimlQMlToWwM0r9hlRY1TLi+7LNhbpiKclKbJx6qM/Hbw366CZf7JnKKeM85k/8eEGi54S85fK48fSQ==",
+          "requires": {
+            "@aws-cdk/aws-iam": "1.18.0",
+            "@aws-cdk/aws-lambda": "1.18.0",
+            "@aws-cdk/aws-s3": "1.18.0",
+            "@aws-cdk/aws-sns": "1.18.0",
+            "@aws-cdk/core": "1.18.0",
+            "@aws-cdk/cx-api": "1.18.0"
+          }
+        }
       }
     },
     "@aws-cdk/aws-elasticloadbalancing": {
@@ -331,6 +376,21 @@
         "@aws-cdk/aws-sqs": "1.18.0",
         "@aws-cdk/aws-stepfunctions": "1.18.0",
         "@aws-cdk/core": "1.18.0"
+      },
+      "dependencies": {
+        "@aws-cdk/aws-cloudformation": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.18.0.tgz",
+          "integrity": "sha512-cCkz9pZwimlQMlToWwM0r9hlRY1TLi+7LNhbpiKclKbJx6qM/Hbw366CZf7JnKKeM85k/8eEGi54S85fK48fSQ==",
+          "requires": {
+            "@aws-cdk/aws-iam": "1.18.0",
+            "@aws-cdk/aws-lambda": "1.18.0",
+            "@aws-cdk/aws-s3": "1.18.0",
+            "@aws-cdk/aws-sns": "1.18.0",
+            "@aws-cdk/core": "1.18.0",
+            "@aws-cdk/cx-api": "1.18.0"
+          }
+        }
       }
     },
     "@aws-cdk/aws-iam": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "lib/**/*"
   ],
   "dependencies": {
+    "@aws-cdk/aws-cloudformation": "^1.18.0",
     "@aws-cdk/aws-codepipeline": "^1.18.0",
     "@aws-cdk/aws-elasticloadbalancingv2": "^1.18.0",
     "@aws-cdk/aws-events-targets": "^1.18.0",

--- a/src/stack-tags.ts
+++ b/src/stack-tags.ts
@@ -19,11 +19,16 @@ export class StackTags implements IAspect {
       node.tags.setTag('Owner', owner);
       node.tags.setTag('Description', description);
 
-      if (node instanceof NestedStack) {
-        const parent = node.parentStack as Stack;
-        node.tags.setTag('ParentStackName', parent.stackName);
+      if (node.nested) {
+        let topStack = node.parentStack as Stack;
+        while (topStack.nested) {
+          topStack = topStack.parentStack as Stack;
+        }
+        node.tags.setTag('TopLevelStackName', topStack.stackName);
+        node.tags.removeTag('Name', 1);
       } else {
         node.tags.setTag('Name', node.stackName);
+        node.tags.removeTag('TopLevelStackName', 1);
       }
     }
   }

--- a/src/stack-tags.ts
+++ b/src/stack-tags.ts
@@ -1,3 +1,4 @@
+import { NestedStack } from '@aws-cdk/aws-cloudformation';
 import { ConstructNode, IAspect, IConstruct, Stack } from '@aws-cdk/core';
 
 /**
@@ -14,10 +15,16 @@ export class StackTags implements IAspect {
       const owner = this.getContext('owner', node.node);
 
       node.tags.setTag('ProjectName', projectName);
-      node.tags.setTag('Name', node.stackName);
       node.tags.setTag('Contact', contact);
       node.tags.setTag('Owner', owner);
       node.tags.setTag('Description', description);
+
+      if (node instanceof NestedStack) {
+        const parent = node.parentStack as Stack;
+        node.tags.setTag('ParentStackName', parent.stackName);
+      } else {
+        node.tags.setTag('Name', node.stackName);
+      }
     }
   }
 

--- a/src/stack-tags.ts
+++ b/src/stack-tags.ts
@@ -19,16 +19,8 @@ export class StackTags implements IAspect {
       node.tags.setTag('Owner', owner);
       node.tags.setTag('Description', description);
 
-      if (node.nested) {
-        let topStack = node.parentStack as Stack;
-        while (topStack.nested) {
-          topStack = topStack.parentStack as Stack;
-        }
-        node.tags.setTag('TopLevelStackName', topStack.stackName);
-        node.tags.removeTag('Name', 1);
-      } else {
+      if (!node.nested) {
         node.tags.setTag('Name', node.stackName);
-        node.tags.removeTag('TopLevelStackName', 1);
       }
     }
   }

--- a/tests/stack-tags.test.ts
+++ b/tests/stack-tags.test.ts
@@ -52,7 +52,6 @@ test('StackTags visit adds all tags on NestedStack', () => {
     { Key: 'Description', Value: 'description-value' },
     { Key: 'Owner', Value: 'owner-value' },
     { Key: 'ProjectName', Value: 'projectName-value' },
-    { Key: 'TopLevelStackName', Value: 'testStack' },
   ];
   expectedTags.forEach(kvp => expect(deeperNestedStack.tags.renderTags()).toContainEqual(kvp));
 });

--- a/tests/stack-tags.test.ts
+++ b/tests/stack-tags.test.ts
@@ -1,16 +1,17 @@
 import { SynthUtils } from '@aws-cdk/assert';
-import { App, Construct, Stack, } from "@aws-cdk/core";
+import { NestedStack } from '@aws-cdk/aws-cloudformation';
+import { App, Construct, Stack } from '@aws-cdk/core';
 import { StackTags } from '../src/index';
 
 test('StackTags can be applied as an Aspect', () => {
   expect(() => {
     const app = new App();
-    app.node.applyAspect(new StackTags())
+    app.node.applyAspect(new StackTags());
   }).not.toThrow();
 });
 
 test('StackTags visit adds all tags from context', () => {
-  const stack = new Stack();
+  const stack = new Stack(undefined, 'testStack');
   const visitor = new StackTags();
 
   stack.node.setContext('owner', 'owner-value');
@@ -22,12 +23,37 @@ test('StackTags visit adds all tags from context', () => {
   // directly for this test
   visitor.visit(stack);
   const expectedTags = [
-    { 'Key': 'Contact', 'Value': 'contact-value' },
-    { 'Key': 'Description', 'Value': 'description-value' },
-    { 'Key': 'Owner', 'Value': 'owner-value' },
-    { 'Key': 'ProjectName', 'Value': 'projectName-value' },
+    { Key: 'Contact', Value: 'contact-value' },
+    { Key: 'Description', Value: 'description-value' },
+    { Key: 'Owner', Value: 'owner-value' },
+    { Key: 'ProjectName', Value: 'projectName-value' },
+    { Key: 'Name', Value: 'testStack' },
   ];
   expectedTags.forEach(kvp => expect(stack.tags.renderTags()).toContainEqual(kvp));
+});
+
+test('StackTags visit adds all tags on NestedStack', () => {
+  const app = new App();
+  const stack = new Stack(app, 'testStack');
+  const nestedStack = new NestedStack(stack, 'testNestedStack');
+  const visitor = new StackTags();
+
+  nestedStack.node.setContext('owner', 'owner-value');
+  nestedStack.node.setContext('contact', 'contact-value');
+  nestedStack.node.setContext('projectName', 'projectName-value');
+  nestedStack.node.setContext('description', 'description-value');
+
+  // Can assume cdk will properly call visit, so calling it
+  // directly for this test
+  visitor.visit(nestedStack);
+  const expectedTags = [
+    { Key: 'Contact', Value: 'contact-value' },
+    { Key: 'Description', Value: 'description-value' },
+    { Key: 'Owner', Value: 'owner-value' },
+    { Key: 'ProjectName', Value: 'projectName-value' },
+    { Key: 'ParentStackName', Value: 'testStack' },
+  ];
+  expectedTags.forEach(kvp => expect(nestedStack.tags.renderTags()).toContainEqual(kvp));
 });
 
 test('StackTags visit ignores non-stacks', () => {
@@ -36,10 +62,10 @@ test('StackTags visit ignores non-stacks', () => {
   const construct = new Construct(stack, 'testConstruct');
   const visitor = new StackTags();
   app.node.applyAspect(visitor);
-  jest.spyOn(visitor, "visit");
+  jest.spyOn(visitor, 'visit');
 
   // Force cdk to do its processing and call the aspects
-  SynthUtils.synthesize(stack); 
+  SynthUtils.synthesize(stack);
 
   // Not really sure of a better way to test this other than to add a few additional types of things and make
   // sure it doesn't die inside of the visit function when it tries to add tags to an object that doesn't have tags
@@ -56,7 +82,7 @@ test('StackTags visit adds an error to the stack node if "owner" does not exist 
   stack.node.setContext('projectName', 'projectName-value');
   stack.node.setContext('description', 'description-value');
   visitor.visit(stack);
-  expect(stack.node.metadata).toContainEqual(expect.objectContaining({ type: "aws:cdk:error" }));
+  expect(stack.node.metadata).toContainEqual(expect.objectContaining({ type: 'aws:cdk:error' }));
 });
 
 test('StackTags visit adds an error to the stack node if "contact" does not exist in context', () => {
@@ -67,7 +93,7 @@ test('StackTags visit adds an error to the stack node if "contact" does not exis
   stack.node.setContext('projectName', 'projectName-value');
   stack.node.setContext('description', 'description-value');
   visitor.visit(stack);
-  expect(stack.node.metadata).toContainEqual(expect.objectContaining({ type: "aws:cdk:error" }));
+  expect(stack.node.metadata).toContainEqual(expect.objectContaining({ type: 'aws:cdk:error' }));
 });
 
 test('StackTags visit adds an error to the stack node if "projectName" does not exist in context', () => {
@@ -78,7 +104,7 @@ test('StackTags visit adds an error to the stack node if "projectName" does not 
   stack.node.setContext('contact', 'contact-value');
   stack.node.setContext('description', 'description-value');
   visitor.visit(stack);
-  expect(stack.node.metadata).toContainEqual(expect.objectContaining({ type: "aws:cdk:error" }));
+  expect(stack.node.metadata).toContainEqual(expect.objectContaining({ type: 'aws:cdk:error' }));
 });
 
 test('StackTags visit adds an error to the stack node if "description" does not exist in context', () => {
@@ -89,5 +115,5 @@ test('StackTags visit adds an error to the stack node if "description" does not 
   stack.node.setContext('contact', 'contact-value');
   stack.node.setContext('projectName', 'projectName-value');
   visitor.visit(stack);
-  expect(stack.node.metadata).toContainEqual(expect.objectContaining({ type: "aws:cdk:error" }));
+  expect(stack.node.metadata).toContainEqual(expect.objectContaining({ type: 'aws:cdk:error' }));
 });

--- a/tests/stack-tags.test.ts
+++ b/tests/stack-tags.test.ts
@@ -36,24 +36,25 @@ test('StackTags visit adds all tags on NestedStack', () => {
   const app = new App();
   const stack = new Stack(app, 'testStack');
   const nestedStack = new NestedStack(stack, 'testNestedStack');
+  const deeperNestedStack = new NestedStack(nestedStack, 'deeperNestedStack');
   const visitor = new StackTags();
 
-  nestedStack.node.setContext('owner', 'owner-value');
-  nestedStack.node.setContext('contact', 'contact-value');
-  nestedStack.node.setContext('projectName', 'projectName-value');
-  nestedStack.node.setContext('description', 'description-value');
+  deeperNestedStack.node.setContext('owner', 'owner-value');
+  deeperNestedStack.node.setContext('contact', 'contact-value');
+  deeperNestedStack.node.setContext('projectName', 'projectName-value');
+  deeperNestedStack.node.setContext('description', 'description-value');
 
   // Can assume cdk will properly call visit, so calling it
   // directly for this test
-  visitor.visit(nestedStack);
+  visitor.visit(deeperNestedStack);
   const expectedTags = [
     { Key: 'Contact', Value: 'contact-value' },
     { Key: 'Description', Value: 'description-value' },
     { Key: 'Owner', Value: 'owner-value' },
     { Key: 'ProjectName', Value: 'projectName-value' },
-    { Key: 'ParentStackName', Value: 'testStack' },
+    { Key: 'TopLevelStackName', Value: 'testStack' },
   ];
-  expectedTags.forEach(kvp => expect(nestedStack.tags.renderTags()).toContainEqual(kvp));
+  expectedTags.forEach(kvp => expect(deeperNestedStack.tags.renderTags()).toContainEqual(kvp));
 });
 
 test('StackTags visit ignores non-stacks', () => {


### PR DESCRIPTION
There was an issue where a `NestedStack` with tags would not deploy properly. While `NestedStack instanceof Stack` is true, the `stackName` property does not behave the same. Instead, [it returns a token based on the context in which it is used](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-cloudformation.NestedStack.html#stackname-span-class-api-icon-api-icon-experimental-title-this-api-element-is-experimental-it-may-change-without-notice-span). This doesn't work for tags – they require a string, and will error upon deploy otherwise.

I couldn't find a way to resolve the nested stack's name, so instead I opted for an alternative of including the parent stack's name as a tag. Not really sure how much it really matters to have this tag in the first place, but couldn't hurt.