### PR TITLE
Bump 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,43 @@
 # Changelog
 
+## [1.2.1](https://github.com/ndlib/ndlib-cdk/compare/v1.2.0...v1.2.1) (2020-01-08)
+
+### Bug Fixes
+
+- Fix issue with applying StackTags to nested stacks ([#21](https://github.com/ndlib/ndlib-cdk/pull/21))
+
 ## [1.2.0](https://github.com/ndlib/ndlib-cdk/compare/v1.1.0...v1.2.0) (2019-12-10)
 
 ### Features
 
-* Added integration with our Slack approval bot ([#16](https://github.com/ndlib/ndlib-cdk/pull/16)), closes [#15](https://github.com/ndlib/ndlib-cdk/issues/15)
+- Added integration with our Slack approval bot ([#16](https://github.com/ndlib/ndlib-cdk/pull/16)), closes [#15](https://github.com/ndlib/ndlib-cdk/issues/15)
 
 ## [1.1.0](https://github.com/ndlib/ndlib-cdk/compare/v1.0.3...v1.1.0) (2019-11-11)
 
 ### Bug Fixes
 
-* Fix prettier ([#7](https://github.com/ndlib/ndlib-cdk/pull/7))
+- Fix prettier ([#7](https://github.com/ndlib/ndlib-cdk/pull/7))
 
 ### Features
 
-* Add CodePipeline email notifications ([#12](https://github.com/ndlib/ndlib-cdk/pull/12)), closes [#9](https://github.com/ndlib/ndlib-cdk/issues/9)
-* Add Archival bucket constructs ([#8](https://github.com/ndlib/ndlib-cdk/pull/8))
-* Add HTTPS ALB ([#5](https://github.com/ndlib/ndlib-cdk/pull/5))
+- Add CodePipeline email notifications ([#12](https://github.com/ndlib/ndlib-cdk/pull/12)), closes [#9](https://github.com/ndlib/ndlib-cdk/issues/9)
+- Add Archival bucket constructs ([#8](https://github.com/ndlib/ndlib-cdk/pull/8))
+- Add HTTPS ALB ([#5](https://github.com/ndlib/ndlib-cdk/pull/5))
 
 ## [1.0.3](https://github.com/ndlib/ndlib-cdk/compare/v1.0.2...v1.0.3) (2019-09-23)
 
 ### Bug Fixes
 
-* Move npm package to @ndlib organization ([b20699](https://github.com/ndlib/ndlib-cdk/commit/b20699374a22b2424bfce961359034a635a05df7))
+- Move npm package to @ndlib organization ([b20699](https://github.com/ndlib/ndlib-cdk/commit/b20699374a22b2424bfce961359034a635a05df7))
 
 ## [1.0.2](https://github.com/ndlib/ndlib-cdk/compare/v1.0.1...v1.0.2) (2019-09-23)
 
 ### Bug Fixes
 
-* Fix publishing issues ([#3](https://github.com/ndlib/ndlib-cdk/pull/3))
+- Fix publishing issues ([#3](https://github.com/ndlib/ndlib-cdk/pull/3))
 
 ## [1.0.1](https://github.com/ndlib/ndlib-cdk/compare/feb80590339abc48a582502704cd4ee108e2041c...v1.0.1) (2019-09-23)
 
 ### Features
 
-* Add StackTags Aspect ([#1](https://github.com/ndlib/ndlib-cdk/pull/1))
+- Add StackTags Aspect ([#1](https://github.com/ndlib/ndlib-cdk/pull/1))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndlib/ndlib-cdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndlib/ndlib-cdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Reusable CDK modules used within Hesburgh Libraries of Notre Dame",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Bug fix release. The formatting changed on the changelog because prettier supports markdown, and I have it run automatically upon saving a file. The default settings for markdown prefer `-` for unordered list items, and I don't see much reason to disagree.