### PR TITLE
Fix dashboard time range

### DIFF
--- a/src/slos/alarms-dashboard.ts
+++ b/src/slos/alarms-dashboard.ts
@@ -102,12 +102,11 @@ export class SLOAlarmsDashboard extends Dashboard {
       return result;
     }, [] as any);
 
-    const superProps = {
-      ...props,
+    const defaultProps = {
       widgets,
-      start: '-P1Y',
+      start: '-P360D',
     };
 
-    super(scope, id, superProps);
+    super(scope, id, { ...defaultProps, ...props });
   }
 }

--- a/src/slos/performance-dashboard.ts
+++ b/src/slos/performance-dashboard.ts
@@ -80,12 +80,11 @@ export class SLOPerformanceDashboard extends Dashboard {
       [[]] as any,
     );
 
-    const superProps = {
-      ...props,
+    const defaultProps = {
       widgets,
-      start: '-P1Y',
+      start: '-P360D',
     };
 
-    super(scope, id, superProps);
+    super(scope, id, { ...defaultProps, ...props });
   }
 }

--- a/tests/slos/alarms-dashboard.test.ts
+++ b/tests/slos/alarms-dashboard.test.ts
@@ -12,6 +12,53 @@ describe('SLOAlarmsDashboard', () => {
     );
   });
 
+  it('allows overriding the period', () => {
+    const slos = [
+      {
+        type: 'CloudfrontAvailability',
+        distributionId: 'myDistributionId',
+        title: 'My Cloudfront',
+        sloThreshold: 0.999,
+      },
+    ];
+    const stack = new Stack();
+    new SLOAlarmsDashboard(stack, 'TestAlarmsDashboard', {
+      slos,
+      dashboardName: 'TestAlarmsDashboard',
+      start: '-P1234D',
+    });
+
+    cdkExpect(stack).to(
+      haveResourceLike('AWS::CloudWatch::Dashboard', {
+        DashboardBody: {
+          'Fn::Join': [
+            '',
+            [
+              '{"start":"-P1234D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 60 minutes","region":"',
+              {
+                Ref: 'AWS::Region',
+              },
+              '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":3600,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"2% of Budget in 60 minutes","value":0.9856,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9827,"max":1}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 6 hours","region":"',
+              {
+                Ref: 'AWS::Region',
+              },
+              '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":21600,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"5% of Budget in 6 hours","value":0.994,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9928,"max":1}}}},{"type":"metric","width":6,"height":6,"x":12,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 1 day","region":"',
+              {
+                Ref: 'AWS::Region',
+              },
+              '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":86400,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"10% of Budget in 1 day","value":0.999,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9988,"max":1}}}},{"type":"metric","width":6,"height":6,"x":18,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 30 days","region":"',
+              {
+                Ref: 'AWS::Region',
+              },
+              '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":2592000,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"100% of Budget in 30 days","value":0.999,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9988,"max":1}}}}]}',
+            ],
+          ],
+        },
+        DashboardName: 'TestAlarmsDashboard',
+      }),
+    );
+  });
+
   describe('CloudfrontAvailability', () => {
     const slos = [
       {
@@ -32,7 +79,7 @@ describe('SLOAlarmsDashboard', () => {
             'Fn::Join': [
               '',
               [
-                '{"start":"-P1Y","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 60 minutes","region":"',
+                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 60 minutes","region":"',
                 {
                   Ref: 'AWS::Region',
                 },
@@ -79,7 +126,7 @@ describe('SLOAlarmsDashboard', () => {
             'Fn::Join': [
               '',
               [
-                '{"start":"-P1Y","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 60 minutes","region":"',
+                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 60 minutes","region":"',
                 {
                   Ref: 'AWS::Region',
                 },
@@ -118,7 +165,7 @@ describe('SLOAlarmsDashboard', () => {
             'Fn::Join': [
               '',
               [
-                '{"start":"-P1Y","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My API - 60 minutes","region":"',
+                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My API - 60 minutes","region":"',
                 {
                   Ref: 'AWS::Region',
                 },
@@ -159,7 +206,7 @@ describe('SLOAlarmsDashboard', () => {
             'Fn::Join': [
               '',
               [
-                '{"start":"-P1Y","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My API - 60 minutes","region":"',
+                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My API - 60 minutes","region":"',
                 {
                   Ref: 'AWS::Region',
                 },

--- a/tests/slos/performance-dashboard.test.ts
+++ b/tests/slos/performance-dashboard.test.ts
@@ -52,7 +52,7 @@ describe('SLOPerformanceDashboard', () => {
           'Fn::Join': [
             '',
             [
-              '{"start":"-P1Y","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - Availability","region":"',
+              '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - Availability","region":"',
               {
                 Ref: 'AWS::Region',
               },
@@ -92,6 +92,41 @@ describe('SLOPerformanceDashboard', () => {
     );
   });
 
+  it('allows overriding the period', () => {
+    const slos = [
+      {
+        type: 'CloudfrontAvailability',
+        distributionId: 'myDistributionId',
+        title: 'My Cloudfront',
+        sloThreshold: 0.999,
+      },
+    ];
+    const stack = new Stack();
+    new SLOPerformanceDashboard(stack, 'TestPerformanceDashboard', {
+      slos,
+      dashboardName: 'TestPerformanceDashboard',
+      start: '-P1234D',
+    });
+
+    cdkExpect(stack).to(
+      haveResourceLike('AWS::CloudWatch::Dashboard', {
+        DashboardBody: {
+          'Fn::Join': [
+            '',
+            [
+              '{"start":"-P1234D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - Availability","region":"',
+              {
+                Ref: 'AWS::Region',
+              },
+              '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":2592000,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"SLO","value":0.999,"fill":"below","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0.995,"max":1}}}}]}',
+            ],
+          ],
+        },
+        DashboardName: 'TestPerformanceDashboard',
+      }),
+    );
+  });
+
   describe('CloudfrontAvailability', () => {
     const slos = [
       {
@@ -115,7 +150,7 @@ describe('SLOPerformanceDashboard', () => {
             'Fn::Join': [
               '',
               [
-                '{"start":"-P1Y","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - Availability","region":"',
+                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - Availability","region":"',
                 {
                   Ref: 'AWS::Region',
                 },
@@ -153,7 +188,7 @@ describe('SLOPerformanceDashboard', () => {
             'Fn::Join': [
               '',
               [
-                '{"start":"-P1Y","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - Latency 200ms","region":"',
+                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - Latency 200ms","region":"',
                 {
                   Ref: 'AWS::Region',
                 },
@@ -183,7 +218,7 @@ describe('SLOPerformanceDashboard', () => {
             'Fn::Join': [
               '',
               [
-                '{"start":"-P1Y","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My API - Availability","region":"',
+                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My API - Availability","region":"',
                 {
                   Ref: 'AWS::Region',
                 },
@@ -215,7 +250,7 @@ describe('SLOPerformanceDashboard', () => {
             'Fn::Join': [
               '',
               [
-                '{"start":"-P1Y","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My API - Latency 2000ms","region":"',
+                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My API - Latency 2000ms","region":"',
                 {
                   Ref: 'AWS::Region',
                 },


### PR DESCRIPTION
Changing the dashboard's default to use a relative time range of 12, 30-day
periods to ensure that the last data point shows the most recent 30 days.
Also changed them to allow overriding the default in a downstream app.