### PR TITLE
Fix Y scale for availability widgets

### DIFF
--- a/src/slos/availability-widget.ts
+++ b/src/slos/availability-widget.ts
@@ -35,7 +35,6 @@ export class AvailabilityWidget extends GraphWidget {
         { label: 'SLO', value: props.sloThreshold, fill: Shading.NONE, color: Colors.orange },
       ];
     }
-    leftYAxis.min = +leftYAxis.min.toFixed(4);
     let title = props.title;
     if (props.addPeriodToTitle === true) {
       title = `${props.title} - ${props.sloWindow.alertWindow.toHumanString()}`;

--- a/tests/slos/alarms-dashboard.test.ts
+++ b/tests/slos/alarms-dashboard.test.ts
@@ -38,7 +38,7 @@ describe('SLOAlarmsDashboard', () => {
               {
                 Ref: 'AWS::Region',
               },
-              '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":3600,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"2% of Budget in 60 minutes","value":0.9856,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9827,"max":1}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 6 hours","region":"',
+              '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":3600,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"2% of Budget in 60 minutes","value":0.9856,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.98272,"max":1}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 6 hours","region":"',
               {
                 Ref: 'AWS::Region',
               },
@@ -83,7 +83,7 @@ describe('SLOAlarmsDashboard', () => {
                 {
                   Ref: 'AWS::Region',
                 },
-                '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":3600,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"2% of Budget in 60 minutes","value":0.9856,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9827,"max":1}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 6 hours","region":"',
+                '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":3600,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"2% of Budget in 60 minutes","value":0.9856,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.98272,"max":1}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 6 hours","region":"',
                 {
                   Ref: 'AWS::Region',
                 },
@@ -169,11 +169,11 @@ describe('SLOAlarmsDashboard', () => {
                 {
                   Ref: 'AWS::Region',
                 },
-                '","metrics":[[{"label":"Availability","expression":"(gatewayRequests - gatewayErrors)/gatewayRequests"}],["AWS/ApiGateway","Count","ApiName","myApiName",{"label":"Requests","period":3600,"stat":"Sum","visible":false,"id":"gatewayRequests"}],["AWS/ApiGateway","5XXError","ApiName","myApiName",{"label":"Error rate","period":3600,"stat":"Sum","visible":false,"id":"gatewayErrors"}]],"annotations":{"horizontal":[{"label":"2% of Budget in 60 minutes","value":0.856,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.99,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.8272,"max":1}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My API - 6 hours","region":"',
+                '","metrics":[[{"label":"Availability","expression":"(gatewayRequests - gatewayErrors)/gatewayRequests"}],["AWS/ApiGateway","Count","ApiName","myApiName",{"label":"Requests","period":3600,"stat":"Sum","visible":false,"id":"gatewayRequests"}],["AWS/ApiGateway","5XXError","ApiName","myApiName",{"label":"Error rate","period":3600,"stat":"Sum","visible":false,"id":"gatewayErrors"}]],"annotations":{"horizontal":[{"label":"2% of Budget in 60 minutes","value":0.856,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.99,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.8271999999999998,"max":1}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My API - 6 hours","region":"',
                 {
                   Ref: 'AWS::Region',
                 },
-                '","metrics":[[{"label":"Availability","expression":"(gatewayRequests - gatewayErrors)/gatewayRequests"}],["AWS/ApiGateway","Count","ApiName","myApiName",{"label":"Requests","period":21600,"stat":"Sum","visible":false,"id":"gatewayRequests"}],["AWS/ApiGateway","5XXError","ApiName","myApiName",{"label":"Error rate","period":21600,"stat":"Sum","visible":false,"id":"gatewayErrors"}]],"annotations":{"horizontal":[{"label":"5% of Budget in 6 hours","value":0.94,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.99,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.928,"max":1}}}},{"type":"metric","width":6,"height":6,"x":12,"y":0,"properties":{"view":"timeSeries","title":"My API - 1 day","region":"',
+                '","metrics":[[{"label":"Availability","expression":"(gatewayRequests - gatewayErrors)/gatewayRequests"}],["AWS/ApiGateway","Count","ApiName","myApiName",{"label":"Requests","period":21600,"stat":"Sum","visible":false,"id":"gatewayRequests"}],["AWS/ApiGateway","5XXError","ApiName","myApiName",{"label":"Error rate","period":21600,"stat":"Sum","visible":false,"id":"gatewayErrors"}]],"annotations":{"horizontal":[{"label":"5% of Budget in 6 hours","value":0.94,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.99,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9279999999999999,"max":1}}}},{"type":"metric","width":6,"height":6,"x":12,"y":0,"properties":{"view":"timeSeries","title":"My API - 1 day","region":"',
                 {
                   Ref: 'AWS::Region',
                 },

--- a/tests/slos/availability-widget.test.ts
+++ b/tests/slos/availability-widget.test.ts
@@ -32,6 +32,10 @@ test('AvailabilityWidget adds horizontal annotation for the SLO threshold', () =
 
 test('AvailabilityWidget by default scales the Y axis based on the order of magnitude of the SLO threshold', () => {
   const expectations = [
+    { sloThreshold: 0.9999999, min: 0.9999995 },
+    { sloThreshold: 0.999999, min: 0.999995 },
+    { sloThreshold: 0.99999, min: 0.99995 },
+    { sloThreshold: 0.9999, min: 0.9995 },
     { sloThreshold: 0.999, min: 0.995 },
     { sloThreshold: 0.99, min: 0.95 },
     { sloThreshold: 0.9, min: 0.5 },
@@ -50,18 +54,16 @@ test('AvailabilityWidget by default scales the Y axis based on the order of magn
       sloThreshold: expectation.sloThreshold,
       sloWindow: Windows.twoPercentLong,
     });
-    expect(widget.toJson()[0].properties.yAxis).toEqual({
-      left: {
-        max: 1,
-        min: expectation.min,
-      },
-    });
+    const leftBounds = widget.toJson()[0].properties.yAxis.left;
+    const minFixed = +leftBounds.min.toFixed(expectation.min.toString().length);
+    expect(minFixed).toEqual(expectation.min);
+    expect(leftBounds.max).toEqual(1);
   });
 });
 
 test('When showing the burn rate threshold, AvailabilityWidget scales the Y axis based on this instead of the SLO threshold', () => {
   const expectations = [
-    { sloThreshold: 0.999, min: 0.9827 },
+    { sloThreshold: 0.999, min: 0.98272 },
     { sloThreshold: 0.99, min: 0.8272 },
     { sloThreshold: 0.9, min: -0.2 },
   ];
@@ -80,12 +82,10 @@ test('When showing the burn rate threshold, AvailabilityWidget scales the Y axis
       sloWindow: Windows.twoPercentLong,
       showBurnRateThreshold: true,
     });
-    expect(widget.toJson()[0].properties.yAxis).toEqual({
-      left: {
-        max: 1,
-        min: expectation.min,
-      },
-    });
+    const leftBounds = widget.toJson()[0].properties.yAxis.left;
+    const minFixed = +leftBounds.min.toFixed(expectation.min.toString().length);
+    expect(minFixed).toEqual(expectation.min);
+    expect(leftBounds.max).toEqual(1);
   });
 });
 


### PR DESCRIPTION
This fixes the scale for availability widgets when the SLO has a high #
of 9s. Previous implementation always clamped it to 4 digits, which would
cause the min and max to both be 1 for high # of 9s. Removed the rounding
entirely from the availability-widget.ts.