### PR TITLE
Bump version 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Change Log
 
-### 1.4.0 (2020/06/11 15:24 +00:00)
+### 1.5.0 (2020/07/08 18:20 +00:00)
+
+- [#37](https://github.com/ndlib/ndlib-cdk/pull/37) Add artifact bucket (@ialford)
+- [#36](https://github.com/ndlib/ndlib-cdk/pull/36) Bump 1.4.0 (@jgondron)
+
+### v1.4.0 (2020/06/11 15:24 +00:00)
 
 - [#35](https://github.com/ndlib/ndlib-cdk/pull/35) Update version workflow (@jgondron)
 - [#34](https://github.com/ndlib/ndlib-cdk/pull/34) Add ElasticSearch SLOs (@jgondron)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndlib/ndlib-cdk",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndlib/ndlib-cdk",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Reusable CDK modules used within Hesburgh Libraries of Notre Dame",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/artifact-bucket.ts
+++ b/src/artifact-bucket.ts
@@ -28,7 +28,7 @@ export class ArtifactBucket extends s3.Bucket {
         conditions: {
           Bool: { 'aws:SecureTransport': false },
         },
-        resources: [this.bucketArn + '*'],
+        resources: [this.bucketArn + '/*'],
       }),
     );
   }

--- a/tests/artifact-bucket.test.ts
+++ b/tests/artifact-bucket.test.ts
@@ -39,7 +39,7 @@ test('Artifact Bucket cannot be accessed via non-secure methods', () => {
                   {
                     'Fn::GetAtt': ['Bucket83908E77', 'Arn'],
                   },
-                  '*',
+                  '/*',
                 ],
               ],
             },


### PR DESCRIPTION
I ran `npm version` and a couple things to note. The git push threw an error, probably because it's trying to push all tags:
```
To github.com:ndlib/ndlib-cdk.git
 * [new tag]         v1.5.0 -> v1.5.0
 ! [rejected]        v1.4.0 -> v1.4.0 (already exists)
error: failed to push some refs to 'git@github.com:ndlib/ndlib-cdk.git'
hint: Updates were rejected because the tag already exists in the remote.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @ndlib/ndlib-cdk@1.5.0 postversion: `git push --set-upstream origin bump-$npm_package_version && git push --tags`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @ndlib/ndlib-cdk@1.5.0 postversion script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/mkirkpa2/.npm/_logs/2020-07-08T18_20_24_710Z-debug.log
```
Is there a way we can update this to just push the newly created tag?

The second thing I noticed is that the PR from the previous version bump is included in the auto-generated changelog, which just looks a little funky. Not sure how to avoid that.