### PR TITLE
docs: add scopes and update contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Create a commit with the proposed changes:
     - `archive-bucket` for code related to the S3 Archival Bucket construct
     - `artifact-bucket` for code related to the S3 Bucket for CodePipeline Artifacts construct
     - `https-alb` for code related to the Application Load Balancer module
-    - `pipeline-notifications` for code related to the notification conmstruct for CodePipeline state changes
+    - `pipeline-notifications` for code related to the notification construct for CodePipeline state changes
     - `slack-approval` for code related to the CodePipeline Slack approval construct
     - `stack-tags` for code related to the creation of required tags on CDK-created resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,51 @@ Can also watch for changes and do both build and tests with the watch script (_N
 npm run watch
 ```
 
+## Commits
+
+Create a commit with the proposed changes:
+
+* Commit title and message (and PR title and description) must adhere to [conventionalcommits](https://www.conventionalcommits.org).
+  * The title must begin with:
+    * `feat(scope): title`
+    * `fix(scope): title`
+    * `refactor(scope): title`
+    * `chore(scope): title`
+    * `build(scope): title`
+    * `ci(scope): title`
+    * `docs(scope): title`
+    * `perf(scope): title`
+    * `test(scope): title`
+  * Title should be lowercase.
+  * No period at the end of the title.
+
+* Commit message should describe _motivation_. Think about your code reviewers and what information they need in
+  order to understand what you did.
+
+* The scope should indicate which module the proposed change impacts.
+  * Current scopes as of 2021-02-24 are:
+    * `slo` for code related to SLOs
+    * `archive-bucket` for code related to the S3 Archival Bucket construct
+    * `artifact-bucket` for code related to the S3 Bucket for CodePipeline Artifacts construct
+    * `https-alb` for code related to the Application Load Balancer module
+    * `pipeline-notifications` for code related to the notification conmstruct for CodePipeline state changes
+    * `slack-approval` for code related to the CodePipeline Slack approval construct
+    * `stack-tags` for code related to the creation of required tags on CDK-created resources
+
+* Commit message should indicate which issues are fixed (if any): `fixes #<issue>` or `closes #<issue>`.
+
+* If not obvious (i.e. from unit tests), describe how you verified that your change works.
+
+* If this commit addresses a JIRA ticket, indicate which JIRA ticket is addressed by including the number in the commit body.
+
+* If this commit includes breaking changes, they must be listed at the end in the following format (notice how multiple breaking changes should be formatted):
+
+```console
+BREAKING CHANGE: Description of what broke and how to achieve this behavior now
+* **module-name:** Another breaking change
+* **module-name:** Yet another breaking change
+```
+
 ## Pull Requests
 
 Before submitting a PR, make sure to run all of the following:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,40 +27,42 @@ npm run watch
 
 Create a commit with the proposed changes:
 
-* Commit title and message (and PR title and description) must adhere to [conventionalcommits](https://www.conventionalcommits.org).
-  * The title must begin with:
-    * `feat(scope): title`
-    * `fix(scope): title`
-    * `refactor(scope): title`
-    * `chore(scope): title`
-    * `build(scope): title`
-    * `ci(scope): title`
-    * `docs(scope): title`
-    * `perf(scope): title`
-    * `test(scope): title`
-  * Title should be lowercase.
-  * No period at the end of the title.
+- Commit title and message (and PR title and description) must adhere to [conventionalcommits](https://www.conventionalcommits.org).
 
-* Commit message should describe _motivation_. Think about your code reviewers and what information they need in
+  - The title must begin with:
+    - `feat(scope): title`
+    - `fix(scope): title`
+    - `refactor(scope): title`
+    - `chore(scope): title`
+    - `build(scope): title`
+    - `ci(scope): title`
+    - `docs(scope): title`
+    - `perf(scope): title`
+    - `test(scope): title`
+  - Title should be lowercase.
+  - No period at the end of the title.
+
+- Commit message should describe _motivation_. Think about your code reviewers and what information they need in
   order to understand what you did.
 
-* The scope should indicate which module the proposed change impacts.
-  * Current scopes as of 2021-02-24 are:
-    * `slo` for code related to SLOs
-    * `archive-bucket` for code related to the S3 Archival Bucket construct
-    * `artifact-bucket` for code related to the S3 Bucket for CodePipeline Artifacts construct
-    * `https-alb` for code related to the Application Load Balancer module
-    * `pipeline-notifications` for code related to the notification conmstruct for CodePipeline state changes
-    * `slack-approval` for code related to the CodePipeline Slack approval construct
-    * `stack-tags` for code related to the creation of required tags on CDK-created resources
+- The scope should indicate which module the proposed change impacts.
 
-* Commit message should indicate which issues are fixed (if any): `fixes #<issue>` or `closes #<issue>`.
+  - Current scopes as of 2021-02-24 are:
+    - `slo` for code related to SLOs
+    - `archive-bucket` for code related to the S3 Archival Bucket construct
+    - `artifact-bucket` for code related to the S3 Bucket for CodePipeline Artifacts construct
+    - `https-alb` for code related to the Application Load Balancer module
+    - `pipeline-notifications` for code related to the notification conmstruct for CodePipeline state changes
+    - `slack-approval` for code related to the CodePipeline Slack approval construct
+    - `stack-tags` for code related to the creation of required tags on CDK-created resources
 
-* If not obvious (i.e. from unit tests), describe how you verified that your change works.
+- Commit message should indicate which issues are fixed (if any): `fixes #<issue>` or `closes #<issue>`.
 
-* If this commit addresses a JIRA ticket, indicate which JIRA ticket is addressed by including the number in the commit body.
+- If not obvious (i.e. from unit tests), describe how you verified that your change works.
 
-* If this commit includes breaking changes, they must be listed at the end in the following format (notice how multiple breaking changes should be formatted):
+- If this commit addresses a JIRA ticket, indicate which JIRA ticket is addressed by including the number in the commit body.
+
+- If this commit includes breaking changes, they must be listed at the end in the following format (notice how multiple breaking changes should be formatted):
 
 ```console
 BREAKING CHANGE: Description of what broke and how to achieve this behavior now

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ Create a commit with the proposed changes:
 - The scope should indicate which module the proposed change impacts.
 
   - Current scopes as of 2021-02-24 are:
+
     - `slo` for code related to SLOs
     - `archive-bucket` for code related to the S3 Archival Bucket construct
     - `artifact-bucket` for code related to the S3 Bucket for CodePipeline Artifacts construct
@@ -55,6 +56,8 @@ Create a commit with the proposed changes:
     - `pipeline-notifications` for code related to the notification construct for CodePipeline state changes
     - `slack-approval` for code related to the CodePipeline Slack approval construct
     - `stack-tags` for code related to the creation of required tags on CDK-created resources
+
+  - If you are proposing a new feature, please create a new scope for the propsed feature, and include it in the commit message, such as `feat(my-new-feature): title`.
 
 - Commit message should indicate which issues are fixed (if any): `fixes #<issue>` or `closes #<issue>`.
 


### PR DESCRIPTION
Adds guidance on leveraging [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) and some guidance on scopes.

I am not particularly sure if it makes sense to articulate the scopes in this manner and I welcome feedback to that point.

closes #48