### PR TITLE
ci: automatic changelog and version bump (no version publish)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,29 +1,24 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-name: Node.js CI
+name: CodeCoverage Report
 on:
-  push:
-    branches-ignore: [ master ]
   pull_request:
     branches: [ master ]
 jobs:
   build-and-test:
+    env:
+      CC_TEST_REPORTER_ID: 8a2453d074f6da747259e1908df35ab1d8c8fa4c3ebacacdf43c2c464bd24abb
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x, 14.x]
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 14.x
     - name: Run NPM CI
       run: npm ci
-    - name: Run NPM Build
-      run: npm run build --if-present
-    - name: Run Linters
-      run: npm run lint
-    - name: Run Unit Tests
-      run: npm test
+    - name: Generate Coverage Report
+      uses: paambaati/codeclimate-action@v2.7.5 #Taking recommendation from https://docs.codeclimate.com/docs/github-actions-test-coverage
+      with:
+        coverageCommand: npm run coverage

--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -1,0 +1,27 @@
+# This workflow will create a changelog based on the Conventional Commits standard and bump the semver accordingly.
+# See: https://www.npmjs.com/package/standard-version for documentation on the tool
+name: Changelog/Version Management
+on:
+  pull_request:
+    branches: [ master ]
+jobs:
+  run-standard-version:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: Config git
+      run: |
+        git config --global user.name $GITHUB_ACTOR
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+    - name: Run Standard Version
+      run: |
+        npx standard-version
+        git fetch origin $GITHUB_HEAD_REF
+        git push -f --follow-tags origin HEAD:$GITHUB_HEAD_REF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.6.3](https://github.com/ndlib/ndlib-cdk/compare/v1.6.2...v1.6.3) (2021-02-25)
+
 ### [1.6.2](https://github.com/ndlib/ndlib-cdk/compare/v1.6.1...v1.6.2) (2021-02-25)
 
 ### [1.6.1](https://github.com/ndlib/ndlib-cdk/compare/v1.6.0...v1.6.1) (2021-02-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## Change Log
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [1.6.2](https://github.com/ndlib/ndlib-cdk/compare/v1.6.1...v1.6.2) (2021-02-25)
+
+### [1.6.1](https://github.com/ndlib/ndlib-cdk/compare/v1.6.0...v1.6.1) (2021-02-25)
 
 ### 1.6.0 (2021/01/12 14:51 +00:00)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndlib/ndlib-cdk",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndlib/ndlib-cdk",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndlib/ndlib-cdk",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Reusable CDK modules used within Hesburgh Libraries of Notre Dame",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndlib/ndlib-cdk",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "description": "Reusable CDK modules used within Hesburgh Libraries of Notre Dame",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
This action should create a CHANGELOG.md and bump the version numbers, as needed per semver, based on the conventional commits standard.

It does not publish a new package, and if the conventionalcommits standard isn't followed, may not generate the expected output.