### PR TITLE
feat(slo): add ability to silence alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ const slos = [
     distributionId: 'E123456789ABC',
     title: 'HTTPS - CDN',
     sloThreshold: 0.999,
+    alarmsEnabled: {
+      High: true,
+      Low: true,
+    },
   },
   {
     type: 'CloudfrontLatency',
@@ -129,6 +133,10 @@ const slos = [
     title: 'HTTPS - CDN',
     sloThreshold: 0.95,
     latencyThreshold: 200,
+    alarmsEnabled: {
+      High: false,
+      Low: false,
+    },
   },
   {
     type: 'ApiAvailability',

--- a/src/slos/alarms.ts
+++ b/src/slos/alarms.ts
@@ -17,6 +17,7 @@ import {
   ElasticSearchLatencySLO,
   IAlertConfig,
   IMultiWindowAlert,
+  Severity,
 } from './types';
 import { Windows } from './windows';
 
@@ -259,6 +260,7 @@ export class SLOAlarms extends Construct {
         alarmRule: SLOAlarms.createCompositeAlarm(childAlarms),
         alarmDescription,
         alarmActions: [topics[topicSeverity].topicArn],
+        actionsEnabled: slo.alarmsEnabled === undefined ? true : slo.alarmsEnabled[topicSeverity] ?? true,
       });
       return { severity: topicSeverity, parentAlarm, childAlarms };
     });

--- a/src/slos/types.ts
+++ b/src/slos/types.ts
@@ -20,6 +20,17 @@ export interface ISLO {
    * The decimal value for the threshold of the SLO.
    */
   readonly sloThreshold: number;
+
+  /**
+   * Optional object to specify which alarm actions should be enabled by severity.
+   * Example object:
+   * {
+   *   High: true,
+   *   Low: false,
+   * }
+   * By default, all actions for all severities are enabled.
+   */
+  readonly alarmsEnabled?: { [key: string]: boolean };
 }
 
 /**
@@ -146,4 +157,9 @@ export enum Colors {
   red = '#d62728',
   blue = '#1f77b4',
   orange = '#ff7f0e',
+}
+
+export enum Severity {
+  HIGH = 'High',
+  LOW = 'Low',
 }

--- a/src/slos/windows.ts
+++ b/src/slos/windows.ts
@@ -1,5 +1,5 @@
 import { Duration } from '@aws-cdk/core';
-import { IAlertConfig } from './types';
+import { IAlertConfig, Severity } from './types';
 
 /**
  * Encapsulates the properties of SLO alerting windows and provides a set of presets
@@ -189,9 +189,9 @@ export class Windows {
    * The multi-window golden standards from Google.
    */
   public static readonly standardMultiWindows = [
-    { windows: [Windows.twoPercentShort, Windows.twoPercentLong], severity: 'High' },
-    { windows: [Windows.fivePercentShort, Windows.fivePercentLong], severity: 'High' },
-    { windows: [Windows.tenPercentShort, Windows.tenPercentLong], severity: 'Low' },
+    { windows: [Windows.twoPercentShort, Windows.twoPercentLong], severity: Severity.HIGH },
+    { windows: [Windows.fivePercentShort, Windows.fivePercentLong], severity: Severity.HIGH },
+    { windows: [Windows.tenPercentShort, Windows.tenPercentLong], severity: Severity.LOW },
   ];
 
   /**
@@ -207,9 +207,9 @@ export class Windows {
    * The multi-window golden standards from Google, limited to one day for AWS alarms.
    */
   public static readonly standardAlarmMultiWindows = [
-    { windows: [Windows.twoPercentShort, Windows.twoPercentLong], severity: 'High' },
-    { windows: [Windows.fivePercentShort, Windows.fivePercentLong], severity: 'High' },
-    { windows: [Windows.tenPercentShort, Windows.tenPercentMedium], severity: 'Low' },
+    { windows: [Windows.twoPercentShort, Windows.twoPercentLong], severity: Severity.HIGH },
+    { windows: [Windows.fivePercentShort, Windows.fivePercentLong], severity: Severity.HIGH },
+    { windows: [Windows.tenPercentShort, Windows.tenPercentMedium], severity: Severity.LOW },
   ];
 
   /**

--- a/tests/slos/alarms.test.ts
+++ b/tests/slos/alarms.test.ts
@@ -46,6 +46,116 @@ describe('SLOAlarms', () => {
     );
   });
 
+  it('enables all alarm actions by default', () => {
+    const stack = new Stack();
+    const slos = [
+      {
+        type: 'CloudfrontAvailability',
+        distributionId: 'myDistributionId',
+        title: 'My Cloudfront',
+        sloThreshold: 0.999,
+      },
+    ];
+    new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+    cdkExpect(stack).to(
+      haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
+        AlarmName: 'My Cloudfront Availability <= 0.999 (High Severity)',
+        ActionsEnabled: true,
+      }),
+    );
+    cdkExpect(stack).to(
+      haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
+        AlarmName: 'My Cloudfront Availability <= 0.999 (Low Severity)',
+        ActionsEnabled: true,
+      }),
+    );
+  });
+
+  it('optionally disables the alarm actions for the high severity alarms', () => {
+    const stack = new Stack();
+    const slos = [
+      {
+        type: 'CloudfrontAvailability',
+        distributionId: 'myDistributionId',
+        title: 'My Cloudfront',
+        sloThreshold: 0.999,
+        alarmsEnabled: {
+          High: false,
+        },
+      },
+    ];
+    new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+    cdkExpect(stack).to(
+      haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
+        AlarmName: 'My Cloudfront Availability <= 0.999 (High Severity)',
+        ActionsEnabled: false,
+      }),
+    );
+    cdkExpect(stack).to(
+      haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
+        AlarmName: 'My Cloudfront Availability <= 0.999 (Low Severity)',
+        ActionsEnabled: true,
+      }),
+    );
+  });
+
+  it('optionally disables the alarm actions for the low severity alarms', () => {
+    const stack = new Stack();
+    const slos = [
+      {
+        type: 'CloudfrontAvailability',
+        distributionId: 'myDistributionId',
+        title: 'My Cloudfront',
+        sloThreshold: 0.999,
+        alarmsEnabled: {
+          Low: false,
+        },
+      },
+    ];
+    new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+    cdkExpect(stack).to(
+      haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
+        AlarmName: 'My Cloudfront Availability <= 0.999 (High Severity)',
+        ActionsEnabled: true,
+      }),
+    );
+    cdkExpect(stack).to(
+      haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
+        AlarmName: 'My Cloudfront Availability <= 0.999 (Low Severity)',
+        ActionsEnabled: false,
+      }),
+    );
+  });
+
+  it('optionally disables the alarm actions for both severity alarms', () => {
+    const stack = new Stack();
+    const slos = [
+      {
+        type: 'CloudfrontAvailability',
+        distributionId: 'myDistributionId',
+        title: 'My Cloudfront',
+        sloThreshold: 0.999,
+        alarmsEnabled: {
+          High: false,
+          Low: false,
+        },
+      },
+    ];
+    new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+    cdkExpect(stack).to(
+      haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
+        AlarmName: 'My Cloudfront Availability <= 0.999 (High Severity)',
+        ActionsEnabled: false,
+      }),
+    );
+    cdkExpect(stack).to(
+      haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
+        AlarmName: 'My Cloudfront Availability <= 0.999 (Low Severity)',
+        ActionsEnabled: false,
+      }),
+    );
+  });
+
   describe('CloudfrontAvailability', () => {
     it('constructs an alarm for the 2.00% of 30 days budget burned in 5 minutes window', () => {
       const stack = new Stack();


### PR DESCRIPTION
This adds the ability to silence alarms by severity type by adding an
optional alarmsEnabled object to the SLO. Ex:
```json
{
  "type": "CloudfrontAvailability",
  "distributionId": "myDistributionId",
  "title": "My Cloudfront",
  "sloThreshold": 0.999,
  "alarmsEnabled": {
    "High": true,
    "Low": false,
  },
},
```

fixes #44