### PR TITLE
Add Edge Lambda constructs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -256,3 +256,36 @@ const project = new Project(stack, `test-project`, {
   },
 });
 ```
+
+## Edge Lambdas
+
+These lambdas are standardized code which may be useful for multiple projects. They should be paired with one or more cloudfronts.
+
+The current list of edge lambdas are:
+
+- SpaRedirectionLambda – Requesting a page other than the index redirects to the origin to serve up the root index file. This is useful for SPAs which handle their own routing.
+- TransclusionLambda – Requesting .shtml files with server-side includes (SSI) triggers this lambda. Include tags in the HTML are replaced with the body of the page file they are requesting, so the origin serves up a flat HTML file.
+
+Each of these constructs implements IEdgeLambda. It will create the function, as well as define a Behavior which can then be used in configuring a CloudFront.
+
+Example usage:
+
+```typescript
+import cdk = require('@aws-cdk/core')
+import { CloudFrontWebDistribution } from '@aws-cdk/aws-cloudfront'
+import { TransclusionLambda } from '@ndlib/ndlib-cdk'
+
+const stack = new cdk.Stack()
+const transclusionLambda = new TransclusionLambda(stack, 'Transclusion', {
+  isDefaultBehavior: true,
+})
+new CloudFrontWebDistribution(this, 'Distribution', {
+  ...
+  originConfigs: [
+    {
+      ...
+      behaviors: [transclusionLambda.behavior],
+    },
+  ],
+})
+```

--- a/README.md
+++ b/README.md
@@ -276,8 +276,10 @@ import { CloudFrontWebDistribution } from '@aws-cdk/aws-cloudfront'
 import { TransclusionLambda } from '@ndlib/ndlib-cdk'
 
 const stack = new cdk.Stack()
+const siteBucket = new Bucket(stack, 'Bucket');
 const transclusionLambda = new TransclusionLambda(stack, 'Transclusion', {
   isDefaultBehavior: true,
+  originBucket: siteBucket,
 })
 new CloudFrontWebDistribution(this, 'Distribution', {
   ...

--- a/copy-lambda-files.sh
+++ b/copy-lambda-files.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # This script will copy lambda source files into the lib output folder.
 # This should be run with the build to ensure that references to lambda code works in the published npm package.
 # It uses the pattern src/edge-lambdas/**/src, and copies everything under the lambda's src folder.
@@ -5,6 +6,6 @@
 files_list=`find "src/edge-lambdas" -type d -name "src" -exec find "{}" -type f -name "*" \;`
 for path in $files_list; do
   # Changes the root folder "src" to "lib"
-  target_path="${path/src/lib}"
+  target_path=$(printf "%s" "$path" | sed -e 's@src@lib@')
   mkdir -p "$(dirname "$target_path")" && cp "$path" "$target_path"
 done

--- a/copy-lambda-files.sh
+++ b/copy-lambda-files.sh
@@ -1,0 +1,10 @@
+# This script will copy lambda source files into the lib output folder.
+# This should be run with the build to ensure that references to lambda code works in the published npm package.
+# It uses the pattern src/edge-lambdas/**/src, and copies everything under the lambda's src folder.
+
+files_list=`find "src/edge-lambdas" -type d -name "src" -exec find "{}" -type f -name "*" \;`
+for path in $files_list; do
+  # Changes the root folder "src" to "lib"
+  target_path="${path/src/lib}"
+  mkdir -p "$(dirname "$target_path")" && cp "$path" "$target_path"
+done

--- a/package-lock.json
+++ b/package-lock.json
@@ -548,6 +548,25 @@
         "@aws-cdk/core": "1.91.0",
         "@aws-cdk/region-info": "1.91.0",
         "constructs": "^3.2.0"
+      },
+      "dependencies": {
+        "@aws-cdk/aws-cloudfront": {
+          "version": "1.91.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.91.0.tgz",
+          "integrity": "sha512-Ho/ijKeu8QXJ6ZH3/vJDgFuFJ+T8ugu86AELNNn+M+38pI50g1kkvgmkB2iQ00zbqgvvy0BzsPRz0lLQN0FSIQ==",
+          "requires": {
+            "@aws-cdk/aws-certificatemanager": "1.91.0",
+            "@aws-cdk/aws-cloudwatch": "1.91.0",
+            "@aws-cdk/aws-ec2": "1.91.0",
+            "@aws-cdk/aws-iam": "1.91.0",
+            "@aws-cdk/aws-kms": "1.91.0",
+            "@aws-cdk/aws-lambda": "1.91.0",
+            "@aws-cdk/aws-s3": "1.91.0",
+            "@aws-cdk/aws-ssm": "1.91.0",
+            "@aws-cdk/core": "1.91.0",
+            "constructs": "^3.2.0"
+          }
+        }
       }
     },
     "@aws-cdk/aws-s3": {
@@ -1443,6 +1462,12 @@
         "jest-diff": "^24.3.0"
       }
     },
+    "@types/node": {
+      "version": "14.14.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
+      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -1646,6 +1671,37 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "aws-sdk": {
+      "version": "2.891.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.891.0.tgz",
+      "integrity": "sha512-st6bKbmA1iWyAz9Fn7CHHNVk/6d51aemPBNpg5sK0kkOSYEob/pCAVSLiN1tGVX6qvjtD41ljeeJDQ3pwRTJfA==",
+      "dev": true,
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "dev": true
+        }
+      }
+    },
     "aws-sign": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz",
@@ -1770,6 +1826,12 @@
           }
         }
       }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -1913,6 +1975,25 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
       }
     },
     "buffer-from": {
@@ -2598,6 +2679,12 @@
         "through": "~2.3.1"
       }
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
+    },
     "exec-sh": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
@@ -3247,6 +3334,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
     },
     "import-local": {
       "version": "2.0.0",
@@ -4070,6 +4163,12 @@
           }
         }
       }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -5130,6 +5229,12 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
       "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc=",
+      "dev": true
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "react-is": {
@@ -6245,6 +6350,24 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
+      }
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -6482,6 +6605,22 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -31,33 +31,36 @@
     "name": "Hesburgh Libraries, University of Notre Dame",
     "url": "https://library.nd.edu"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/ndlib/ndlib-cdk/issues"
   },
   "homepage": "https://github.com/ndlib/ndlib-cdk#readme",
   "devDependencies": {
-    "@aws-cdk/assert": "^1.45.0",
+    "@aws-cdk/assert": "^1.91.0",
     "@types/jest": "^24.0.23",
+    "@types/node": "^14.14.41",
+    "aws-sdk": "^2.891.0",
+    "github-changes": "^1.1.2",
     "jest": "^24.9.0",
     "prettier": "^1.19.1",
     "ts-jest": "^24.2.0",
     "tsc-watch": "^3.0.2",
     "tslint": "^5.20.1",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.7.3",
-    "github-changes": "^1.1.2"
+    "typescript": "^3.7.3"
   },
   "files": [
     "lib/**/*"
   ],
   "dependencies": {
-    "@aws-cdk/aws-cloudformation": "^1.45.0",
-    "@aws-cdk/aws-cloudwatch": "^1.45.0",
-    "@aws-cdk/aws-codepipeline": "^1.45.0",
-    "@aws-cdk/aws-elasticloadbalancingv2": "^1.45.0",
-    "@aws-cdk/aws-events-targets": "^1.45.0",
-    "@aws-cdk/aws-sns": "^1.45.0",
-    "@aws-cdk/core": "^1.45.0"
+    "@aws-cdk/aws-cloudformation": "^1.91.0",
+    "@aws-cdk/aws-cloudfront": "^1.91.0",
+    "@aws-cdk/aws-cloudwatch": "^1.91.0",
+    "@aws-cdk/aws-codepipeline": "^1.91.0",
+    "@aws-cdk/aws-elasticloadbalancingv2": "^1.91.0",
+    "@aws-cdk/aws-events-targets": "^1.91.0",
+    "@aws-cdk/aws-sns": "^1.91.0",
+    "@aws-cdk/core": "^1.91.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest --config jestconfig.json",
     "coverage": "jest --config jestconfig.json --coverage",
-    "build": "tsc",
+    "build": "tsc && ./copy-lambda-files.sh",
     "format": "tslint --fix -p tsconfig.json && prettier --write \"@(src|tests)/**/*.@(ts|js|json|md|yml)\" \"*.@(ts|js|json|md|yml)\"",
     "lint": "tslint -p tsconfig.json && prettier --check \"@(src|tests)/**/*.@(ts|js|json|md|yml)\" \"*.@(ts|js|json|md|yml)\"",
     "generate-changelog": "github-changes -n ${npm_package_version} -o ndlib -r ndlib-cdk --only-pulls --use-commit-body",

--- a/src/edge-lambdas/index.ts
+++ b/src/edge-lambdas/index.ts
@@ -1,0 +1,27 @@
+import { Behavior, LambdaEdgeEventType } from '@aws-cdk/aws-cloudfront';
+import * as lambda from '@aws-cdk/aws-lambda';
+import { Duration } from '@aws-cdk/core';
+
+// This enables setting certain props when constructing a new function, but not all of them.
+// There would be no reason to override the code path or handler, for instance.
+export interface IEdgeLambdaProps {
+  // These props relate to the Function
+  description?: string;
+  timeout?: Duration;
+  // These props relate to the CloudFront Behavior
+  // eventType is not required by the interface, but it IS required by the CloudFront. Implementation should provide default.
+  eventType?: LambdaEdgeEventType;
+  isDefaultBehavior: boolean;
+  pathPattern?: string;
+  minTtl?: Duration;
+  maxTtl?: Duration;
+  defaultTtl?: Duration;
+}
+
+export interface IEdgeLambda {
+  function: lambda.Function;
+  behavior: Behavior;
+}
+
+export * from './spaRedirectionLambda';
+export * from './transclusionLambda';

--- a/src/edge-lambdas/spaRedirectionLambda/index.ts
+++ b/src/edge-lambdas/spaRedirectionLambda/index.ts
@@ -1,0 +1,71 @@
+/* tslint:disable:max-classes-per-file */
+import { Behavior, CloudFrontAllowedMethods, LambdaEdgeEventType } from '@aws-cdk/aws-cloudfront';
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as cdk from '@aws-cdk/core';
+import * as path from 'path';
+import { IEdgeLambda, IEdgeLambdaProps } from '../index';
+
+export interface ISpaRedirectionLambdaProps extends IEdgeLambdaProps {
+  /**
+   * List of file extensions which should redirect. INCLUDE the dot. (Ex: .html)
+   * If omitted, a default list of extensions will be used.
+   */
+  fileExtensions?: string[];
+}
+
+export class SpaRedirectionLambda extends cdk.Construct implements IEdgeLambda {
+  public readonly function: lambda.Function;
+  public readonly behavior: Behavior;
+
+  constructor(scope: cdk.Construct, id: string, props: ISpaRedirectionLambdaProps) {
+    super(scope, id);
+
+    this.function = new lambda.Function(scope, `${id}Function`, {
+      code: lambda.Code.fromAsset(path.join(__dirname, 'src')),
+      description: 'Basic rewrite rule to send directory requests to appropriate locations in the SPA.',
+      handler: 'handler.handler',
+      runtime: lambda.Runtime.NODEJS_12_X,
+      timeout: cdk.Duration.seconds(10),
+      environment: {
+        EXTENSIONS: (props.fileExtensions?.length
+          ? props.fileExtensions
+          : [
+              '.html',
+              '.js',
+              '.json',
+              '.css',
+              '.jpg',
+              '.jpeg',
+              '.png',
+              '.ico',
+              '.map',
+              '.txt',
+              '.kml',
+              '.svg',
+              '.webmanifest',
+              '.webp',
+              '.xml',
+              '.zip',
+            ]
+        ).join(','),
+      },
+      ...props,
+    });
+
+    this.behavior = {
+      allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
+      compress: true,
+      isDefaultBehavior: props.isDefaultBehavior,
+      pathPattern: props.pathPattern,
+      lambdaFunctionAssociations: [
+        {
+          eventType: props.eventType || LambdaEdgeEventType.ORIGIN_REQUEST,
+          lambdaFunction: this.function.currentVersion,
+        },
+      ],
+      minTtl: props.minTtl,
+      maxTtl: props.maxTtl,
+      defaultTtl: props.defaultTtl,
+    };
+  }
+}

--- a/src/edge-lambdas/spaRedirectionLambda/src/handler.js
+++ b/src/edge-lambdas/spaRedirectionLambda/src/handler.js
@@ -1,0 +1,26 @@
+const path = require('path');
+
+// https://medium.com/radon-dev/redirection-on-cloudfront-with-lambda-edge-e72fd633603e
+exports.handler = (event, context, callback) => {
+  const { request } = event.Records[0].cf;
+
+  const parsedPath = path.parse(request.uri);
+  let newUri;
+
+  // this is not the best way that this we may need to do an s3 head request to fully
+  // detect if the file exists.
+  const validExtensions = process.env.EXTENSIONS.split(',');
+  // if there is no extension or it is not in one of the extensions we expect to find on the
+  // server.
+  if (parsedPath.ext === '' || !validExtensions.includes(parsedPath.ext)) {
+    newUri = path.join(parsedPath.dir, parsedPath.base, 'index.html');
+  } else {
+    newUri = request.uri;
+  }
+
+  // Replace the received URI with the URI that includes the index page
+  request.uri = newUri;
+
+  // Return to CloudFront
+  return callback(null, request);
+};

--- a/src/edge-lambdas/spaRedirectionLambda/test/handler.test.js
+++ b/src/edge-lambdas/spaRedirectionLambda/test/handler.test.js
@@ -1,0 +1,74 @@
+// To run this
+// yarn run jest handler.test.js
+//
+const testHandler = require('../src/handler').handler;
+
+// Function to make it easier to create test event objects
+// to send to the test handler. Returns a cloudfront origin
+// event object with the given uri.
+describe('URL ReWrites', () => {
+  process.env.EXTENSIONS = [
+    '.html',
+    '.js',
+    '.json',
+    '.css',
+    '.jpg',
+    '.jpeg',
+    '.png',
+    '.ico',
+    '.map',
+    '.txt',
+    '.kml',
+    '.svg',
+    '.webmanifest',
+    '.webp',
+    '.xml',
+    '.zip',
+  ].join(',');
+
+  const newTestEvent = uri => ({
+    Records: [
+      {
+        cf: {
+          response: {
+            status: 200,
+          },
+          request: {
+            uri: uri,
+          },
+        },
+      },
+    ],
+  });
+
+  // Array of requested URIs and what we expect the function to rewrite it to
+  const testUris = [
+    { test_uri: '', expected_uri: 'index.html' },
+    { test_uri: '/', expected_uri: '/index.html' },
+    { test_uri: '/sub_path', expected_uri: '/sub_path/index.html' },
+    { test_uri: '/sub_path/', expected_uri: '/sub_path/index.html' },
+    { test_uri: '/sub_path/sub_path', expected_uri: '/sub_path/sub_path/index.html' },
+    { test_uri: '/sub_path/sub_path/', expected_uri: '/sub_path/sub_path/index.html' },
+    { test_uri: '/page.html', expected_uri: '/page.html' },
+    { test_uri: '/sub.path', expected_uri: '/sub.path/index.html' },
+    { test_uri: '/1999.024', expected_uri: '/1999.024/index.html' },
+    { test_uri: '/1239.024.534', expected_uri: '/1239.024.534/index.html' },
+  ];
+
+  // Loop through each of the test URIs and make sure the function under test rewrites
+  // the request correctly
+  testUris.forEach(testObj => {
+    test('when URI "' + testObj.test_uri + '" is requested, rewrites to: "' + testObj.expected_uri + '"', () => {
+      const testEvent = newTestEvent(testObj.test_uri);
+      // When AWS executes a Lambda, it passes in a callback function to your handler. It
+      // expects your handler to call the passed in function with the resultant data.
+      // This is a mock callback that we'll pass to the handler we are testing so that we can
+      // simulate what will happen when deployed. This mock function is where we inspect
+      // the data that the handler will ultimately be returned to Cloudfront.
+      const mockCallback = (ignore, data) => {
+        expect(data).toEqual({ uri: testObj.expected_uri });
+      };
+      testHandler(testEvent, null, mockCallback);
+    });
+  });
+});

--- a/src/edge-lambdas/transclusionLambda/index.ts
+++ b/src/edge-lambdas/transclusionLambda/index.ts
@@ -1,0 +1,40 @@
+/* tslint:disable:max-classes-per-file */
+import { Behavior, CloudFrontAllowedMethods, LambdaEdgeEventType } from '@aws-cdk/aws-cloudfront';
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as cdk from '@aws-cdk/core';
+import * as path from 'path';
+import { IEdgeLambda, IEdgeLambdaProps } from '../index';
+
+export class TransclusionLambda extends cdk.Construct implements IEdgeLambda {
+  public readonly function: lambda.Function;
+  public readonly behavior: Behavior;
+
+  constructor(scope: cdk.Construct, id: string, props: IEdgeLambdaProps) {
+    super(scope, id);
+
+    this.function = new lambda.Function(scope, `${id}Function`, {
+      code: lambda.Code.fromAsset(path.join(__dirname, 'src')),
+      description: 'Handles includes inside shtml files so we can serve them up correctly.',
+      handler: 'handler.handler',
+      runtime: lambda.Runtime.NODEJS_12_X,
+      timeout: cdk.Duration.seconds(10),
+      ...props,
+    });
+
+    this.behavior = {
+      allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
+      compress: true,
+      isDefaultBehavior: props.isDefaultBehavior,
+      pathPattern: props.pathPattern || '*.shtml',
+      lambdaFunctionAssociations: [
+        {
+          eventType: props.eventType || LambdaEdgeEventType.ORIGIN_REQUEST,
+          lambdaFunction: this.function.currentVersion,
+        },
+      ],
+      minTtl: props.minTtl,
+      maxTtl: props.maxTtl,
+      defaultTtl: props.defaultTtl,
+    };
+  }
+}

--- a/src/edge-lambdas/transclusionLambda/index.ts
+++ b/src/edge-lambdas/transclusionLambda/index.ts
@@ -1,15 +1,24 @@
 /* tslint:disable:max-classes-per-file */
 import { Behavior, CloudFrontAllowedMethods, LambdaEdgeEventType } from '@aws-cdk/aws-cloudfront';
+import { PolicyStatement } from '@aws-cdk/aws-iam';
 import * as lambda from '@aws-cdk/aws-lambda';
+import { Bucket } from '@aws-cdk/aws-s3';
 import * as cdk from '@aws-cdk/core';
 import * as path from 'path';
 import { IEdgeLambda, IEdgeLambdaProps } from '../index';
+
+export interface ITransclusionLambdaProps extends IEdgeLambdaProps {
+  /**
+   * The bucket where site files are hosted. Needed to grant permissions so the lambda can fetch objects.
+   */
+  originBucket: Bucket;
+}
 
 export class TransclusionLambda extends cdk.Construct implements IEdgeLambda {
   public readonly function: lambda.Function;
   public readonly behavior: Behavior;
 
-  constructor(scope: cdk.Construct, id: string, props: IEdgeLambdaProps) {
+  constructor(scope: cdk.Construct, id: string, props: ITransclusionLambdaProps) {
     super(scope, id);
 
     this.function = new lambda.Function(scope, `${id}Function`, {
@@ -20,6 +29,12 @@ export class TransclusionLambda extends cdk.Construct implements IEdgeLambda {
       timeout: cdk.Duration.seconds(10),
       ...props,
     });
+    this.function.addToRolePolicy(
+      new PolicyStatement({
+        resources: [props.originBucket.bucketArn + '/*'],
+        actions: ['s3:GetObject*'],
+      }),
+    );
 
     this.behavior = {
       allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,

--- a/src/edge-lambdas/transclusionLambda/src/handler.js
+++ b/src/edge-lambdas/transclusionLambda/src/handler.js
@@ -1,0 +1,87 @@
+const AWS = require('aws-sdk'); // eslint-disable-line node/no-unpublished-require
+const s3 = new AWS.S3({ region: 'us-east-1', apiVersion: '2006-03-01' });
+const path = require('path');
+
+module.exports.getFromS3 = async (bucketName, objectPath) => {
+  // The key for s3 documents does NOT include a root level slash at the beginning
+  if (objectPath.startsWith('/')) {
+    objectPath = objectPath.substring(1);
+  }
+  console.log('Fetch from s3:', bucketName + '/' + objectPath);
+  return s3
+    .getObject({
+      Bucket: bucketName,
+      Key: objectPath,
+    })
+    .promise();
+};
+
+const transclude = async (body, bucketName, parentDir) => {
+  // Get the paths of files to include from strings like: <!--#include virtual="foo/bar.shtml" -->
+  const includesRegex = /<!--\s?#include virtual="(.+?)"\s?-->/g;
+  const matches = Array.from(body.matchAll(includesRegex));
+
+  // Fetch all included files
+  const promises = matches.map(match => exports.getFromS3(bucketName, path.resolve(parentDir, match[1])));
+  return Promise.all(promises).then(async s3results => {
+    // Also need to transclude the included page if it is an shtml file
+    const includedBodies = await s3results.map(async (response, index) => {
+      const pageBody = response.Body.toString();
+      const filepath = matches[index][1];
+      console.log('retrieved', filepath);
+      const pageDir = path.resolve(parentDir, path.dirname(filepath));
+      const resultBody =
+        path.extname(filepath) === '.shtml' ? await transclude(pageBody, bucketName, pageDir) : pageBody;
+      return resultBody;
+    });
+    return Promise.all(includedBodies).then(async resolvedBodies => {
+      resolvedBodies.forEach(async (includedBody, index) => {
+        body = body.replace(matches[index][0], includedBody);
+      });
+      return body;
+    });
+  });
+};
+
+module.exports.handler = async (event, context, callback) => {
+  const request = event.Records[0].cf.request;
+  const headers = request.headers;
+  const uri = request.uri;
+
+  console.log('Request:', JSON.stringify(request, null, 2));
+  if (uri === '/' || path.extname(uri) === '.shtml') {
+    // Get the name of the origin bucket that was fetched from
+    // Ex: hackathon-dev-site-333680067100.s3.us-east-1.amazonaws.com -> hackathon-dev-site-333680067100
+    const bucketName = request.origin.s3.domainName.replace(/\.s3\..*\.amazonaws.com/, '');
+
+    // Now get the requested file
+    const filepath = uri === '/' ? '/index.shtml' : uri;
+    const response = await exports.getFromS3(bucketName, filepath);
+
+    // Transclude any included files in the response body
+    const modifiedBody = await transclude(response.Body.toString(), bucketName, path.dirname(filepath));
+    return callback(null, {
+      body: modifiedBody,
+      bodyEncoding: 'text',
+      status: '200',
+      statusDescription: 'OK',
+      headers: {
+        'content-type': [
+          {
+            key: 'Content-Type',
+            value: 'text/html; charset=UTF-8',
+          },
+        ],
+        'cache-control': [
+          {
+            key: 'Cache-Control',
+            value: 'max-age=3600',
+          },
+        ],
+      },
+    });
+  } else {
+    // Was not an shtml file so we can serve it up as is without additional processing
+    return callback(null, request);
+  }
+};

--- a/src/edge-lambdas/transclusionLambda/test/handler.test.js
+++ b/src/edge-lambdas/transclusionLambda/test/handler.test.js
@@ -1,0 +1,119 @@
+const lambdaHandler = require('../src/handler');
+
+const hostname = 'www.example.com';
+const indexBody = `
+  <html>
+  <body>
+    <!--#include virtual="/include1.shtml" -->
+    <div>This is an example.</div>
+    <!-- #include virtual="/include2.shtml" -->
+  </body>
+  </html>
+`;
+const firstIncludeBody = `<div>
+      <h1>Navigation or something</h1>
+      <!-- #include virtual="/foo/nestedInclude.shtml"-->
+    </div>
+`;
+const nestedIncludeBody = '<span>I go under the nav heading</span>';
+const secondIncludeBody = '<div>a footer</div>';
+
+const testEvent = {
+  Records: [
+    {
+      cf: {
+        response: {
+          status: 200,
+          body: indexBody,
+        },
+        request: {
+          uri: '/index.shtml',
+          headers: {
+            host: [
+              {
+                key: 'Host',
+                value: hostname,
+              },
+            ],
+          },
+          origin: {
+            s3: {
+              domainName: hostname,
+            },
+          },
+        },
+      },
+    },
+  ],
+};
+
+describe('transclusionLambda handler', () => {
+  beforeEach(() => {
+    console.log = jest.fn();
+    lambdaHandler.getFromS3 = jest.fn().mockImplementation((bucketName, objectPath) => {
+      let responseBody;
+      switch (objectPath) {
+        case '/':
+        case '/index.shtml':
+          responseBody = indexBody;
+          break;
+        case '/include1.shtml':
+          responseBody = firstIncludeBody;
+          break;
+        case '/include2.shtml':
+          responseBody = secondIncludeBody;
+          break;
+        case '/foo/nestedInclude.shtml':
+          responseBody = nestedIncludeBody;
+          break;
+        default:
+          throw new Error('Unexpected path: ' + objectPath);
+      }
+      return Promise.resolve({
+        Body: responseBody,
+      });
+    });
+  });
+
+  test('recursively replaces includes with correct body content', async () => {
+    const mockCallback = (ignore, data) => {
+      const expectedBody = `
+  <html>
+  <body>
+    <div>
+      <h1>Navigation or something</h1>
+      <span>I go under the nav heading</span>
+    </div>
+
+    <div>This is an example.</div>
+    <div>a footer</div>
+  </body>
+  </html>
+`;
+      const expected = {
+        body: expectedBody,
+        bodyEncoding: 'text',
+        status: '200',
+        statusDescription: 'OK',
+        headers: {
+          'content-type': [
+            {
+              key: 'Content-Type',
+              value: 'text/html; charset=UTF-8',
+            },
+          ],
+          'cache-control': [
+            {
+              key: 'Cache-Control',
+              value: 'max-age=3600',
+            },
+          ],
+        },
+      };
+      expect(data).toEqual(expected);
+      expect(lambdaHandler.getFromS3).toHaveBeenCalledTimes(4);
+    };
+
+    await lambdaHandler.handler(testEvent, null, mockCallback);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export * from './slos/alarms-dashboard';
 export * from './slos/performance-dashboard';
 export * from './artifact-bucket';
 export * from './docker-codebuild-action';
+export * from './edge-lambdas';

--- a/tests/edge-lambdas/spaRedirectionLambda/index.test.ts
+++ b/tests/edge-lambdas/spaRedirectionLambda/index.test.ts
@@ -1,0 +1,79 @@
+import { expect as expectCDK, haveResourceLike } from '@aws-cdk/assert';
+import { CloudFrontAllowedMethods, LambdaEdgeEventType } from '@aws-cdk/aws-cloudfront';
+import { Stack, Duration } from '@aws-cdk/core';
+import { SpaRedirectionLambda } from '../../../src/edge-lambdas/spaRedirectionLambda';
+
+describe('SpaRedirectionLambda', () => {
+  test('creates lambda function with default props', () => {
+    const stack = new Stack();
+    const testLambda = new SpaRedirectionLambda(stack, 'Lambda', {
+      isDefaultBehavior: false,
+    });
+    expect(testLambda.behavior).toMatchObject({
+      allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
+      compress: true,
+      isDefaultBehavior: false,
+      lambdaFunctionAssociations: [
+        {
+          eventType: LambdaEdgeEventType.ORIGIN_REQUEST,
+          lambdaFunction: testLambda.function.currentVersion,
+        },
+      ],
+    });
+    expectCDK(stack).to(
+      haveResourceLike('AWS::Lambda::Function', {
+        Description: 'Basic rewrite rule to send directory requests to appropriate locations in the SPA.',
+        Handler: 'handler.handler',
+        Runtime: 'nodejs12.x',
+        Timeout: 10,
+        Environment: {
+          Variables: {
+            EXTENSIONS: '.html,.js,.json,.css,.jpg,.jpeg,.png,.ico,.map,.txt,.kml,.svg,.webmanifest,.webp,.xml,.zip',
+          },
+        },
+      }),
+    );
+  });
+
+  test('creates lambda function with overridden props', () => {
+    const stack = new Stack();
+    const testLambda = new SpaRedirectionLambda(stack, 'Lambda', {
+      description: 'My transclusion lambda for my fancy stack.',
+      timeout: Duration.seconds(123),
+      isDefaultBehavior: true,
+      pathPattern: '/public/',
+      minTtl: Duration.seconds(100),
+      maxTtl: Duration.seconds(200),
+      defaultTtl: Duration.seconds(150),
+      fileExtensions: ['.pdf', '.abcde'],
+    });
+    expect(testLambda.behavior).toMatchObject({
+      allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
+      compress: true,
+      isDefaultBehavior: true,
+      pathPattern: '/public/',
+      lambdaFunctionAssociations: [
+        {
+          eventType: LambdaEdgeEventType.ORIGIN_REQUEST,
+          lambdaFunction: testLambda.function.currentVersion,
+        },
+      ],
+      minTtl: Duration.seconds(100),
+      maxTtl: Duration.seconds(200),
+      defaultTtl: Duration.seconds(150),
+    });
+    expectCDK(stack).to(
+      haveResourceLike('AWS::Lambda::Function', {
+        Description: 'My transclusion lambda for my fancy stack.',
+        Handler: 'handler.handler',
+        Runtime: 'nodejs12.x',
+        Timeout: 123,
+        Environment: {
+          Variables: {
+            EXTENSIONS: '.pdf,.abcde',
+          },
+        },
+      }),
+    );
+  });
+});

--- a/tests/edge-lambdas/spaRedirectionLambda/index.test.ts
+++ b/tests/edge-lambdas/spaRedirectionLambda/index.test.ts
@@ -4,38 +4,44 @@ import { Stack, Duration } from '@aws-cdk/core';
 import { SpaRedirectionLambda } from '../../../src/edge-lambdas/spaRedirectionLambda';
 
 describe('SpaRedirectionLambda', () => {
-  test('creates lambda function with default props', () => {
+  describe('with default props', () => {
     const stack = new Stack();
     const testLambda = new SpaRedirectionLambda(stack, 'Lambda', {
       isDefaultBehavior: false,
     });
-    expect(testLambda.behavior).toMatchObject({
-      allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
-      compress: true,
-      isDefaultBehavior: false,
-      lambdaFunctionAssociations: [
-        {
-          eventType: LambdaEdgeEventType.ORIGIN_REQUEST,
-          lambdaFunction: testLambda.function.currentVersion,
-        },
-      ],
-    });
-    expectCDK(stack).to(
-      haveResourceLike('AWS::Lambda::Function', {
-        Description: 'Basic rewrite rule to send directory requests to appropriate locations in the SPA.',
-        Handler: 'handler.handler',
-        Runtime: 'nodejs12.x',
-        Timeout: 10,
-        Environment: {
-          Variables: {
-            EXTENSIONS: '.html,.js,.json,.css,.jpg,.jpeg,.png,.ico,.map,.txt,.kml,.svg,.webmanifest,.webp,.xml,.zip',
+
+    test('creates function', () => {
+      expectCDK(stack).to(
+        haveResourceLike('AWS::Lambda::Function', {
+          Description: 'Basic rewrite rule to send directory requests to appropriate locations in the SPA.',
+          Handler: 'handler.handler',
+          Runtime: 'nodejs12.x',
+          Timeout: 10,
+          Environment: {
+            Variables: {
+              EXTENSIONS: '.html,.js,.json,.css,.jpg,.jpeg,.png,.ico,.map,.txt,.kml,.svg,.webmanifest,.webp,.xml,.zip',
+            },
           },
-        },
-      }),
-    );
+        }),
+      );
+    });
+
+    test('creates valid behavior configuration', () => {
+      expect(testLambda.behavior).toMatchObject({
+        allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
+        compress: true,
+        isDefaultBehavior: false,
+        lambdaFunctionAssociations: [
+          {
+            eventType: LambdaEdgeEventType.ORIGIN_REQUEST,
+            lambdaFunction: testLambda.function.currentVersion,
+          },
+        ],
+      });
+    });
   });
 
-  test('creates lambda function with overridden props', () => {
+  describe('with overridden props', () => {
     const stack = new Stack();
     const testLambda = new SpaRedirectionLambda(stack, 'Lambda', {
       description: 'My transclusion lambda for my fancy stack.',
@@ -47,33 +53,39 @@ describe('SpaRedirectionLambda', () => {
       defaultTtl: Duration.seconds(150),
       fileExtensions: ['.pdf', '.abcde'],
     });
-    expect(testLambda.behavior).toMatchObject({
-      allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
-      compress: true,
-      isDefaultBehavior: true,
-      pathPattern: '/public/',
-      lambdaFunctionAssociations: [
-        {
-          eventType: LambdaEdgeEventType.ORIGIN_REQUEST,
-          lambdaFunction: testLambda.function.currentVersion,
-        },
-      ],
-      minTtl: Duration.seconds(100),
-      maxTtl: Duration.seconds(200),
-      defaultTtl: Duration.seconds(150),
-    });
-    expectCDK(stack).to(
-      haveResourceLike('AWS::Lambda::Function', {
-        Description: 'My transclusion lambda for my fancy stack.',
-        Handler: 'handler.handler',
-        Runtime: 'nodejs12.x',
-        Timeout: 123,
-        Environment: {
-          Variables: {
-            EXTENSIONS: '.pdf,.abcde',
+
+    test('overrides defaults on function', () => {
+      expectCDK(stack).to(
+        haveResourceLike('AWS::Lambda::Function', {
+          Description: 'My transclusion lambda for my fancy stack.',
+          Handler: 'handler.handler',
+          Runtime: 'nodejs12.x',
+          Timeout: 123,
+          Environment: {
+            Variables: {
+              EXTENSIONS: '.pdf,.abcde',
+            },
           },
-        },
-      }),
-    );
+        }),
+      );
+    });
+
+    test('overrides defaults on behavior', () => {
+      expect(testLambda.behavior).toMatchObject({
+        allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
+        compress: true,
+        isDefaultBehavior: true,
+        pathPattern: '/public/',
+        lambdaFunctionAssociations: [
+          {
+            eventType: LambdaEdgeEventType.ORIGIN_REQUEST,
+            lambdaFunction: testLambda.function.currentVersion,
+          },
+        ],
+        minTtl: Duration.seconds(100),
+        maxTtl: Duration.seconds(200),
+        defaultTtl: Duration.seconds(150),
+      });
+    });
   });
 });

--- a/tests/edge-lambdas/transclusionLambda/index.test.ts
+++ b/tests/edge-lambdas/transclusionLambda/index.test.ts
@@ -1,0 +1,69 @@
+import { expect as expectCDK, haveResourceLike } from '@aws-cdk/assert';
+import { CloudFrontAllowedMethods, LambdaEdgeEventType } from '@aws-cdk/aws-cloudfront';
+import { Stack, Duration } from '@aws-cdk/core';
+import { TransclusionLambda } from '../../../src/edge-lambdas/transclusionLambda';
+
+describe('TransclusionLambda', () => {
+  test('creates lambda function with default props', () => {
+    const stack = new Stack();
+    const testLambda = new TransclusionLambda(stack, 'Lambda', {
+      isDefaultBehavior: false,
+    });
+    expect(testLambda.behavior).toMatchObject({
+      allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
+      compress: true,
+      isDefaultBehavior: false,
+      pathPattern: '*.shtml',
+      lambdaFunctionAssociations: [
+        {
+          eventType: LambdaEdgeEventType.ORIGIN_REQUEST,
+          lambdaFunction: testLambda.function.currentVersion,
+        },
+      ],
+    });
+    expectCDK(stack).to(
+      haveResourceLike('AWS::Lambda::Function', {
+        Description: 'Handles includes inside shtml files so we can serve them up correctly.',
+        Handler: 'handler.handler',
+        Runtime: 'nodejs12.x',
+        Timeout: 10,
+      }),
+    );
+  });
+
+  test('creates lambda function with overridden props', () => {
+    const stack = new Stack();
+    const testLambda = new TransclusionLambda(stack, 'Lambda', {
+      description: 'My transclusion lambda for my fancy stack.',
+      timeout: Duration.seconds(123),
+      isDefaultBehavior: true,
+      pathPattern: '/public/',
+      minTtl: Duration.seconds(100),
+      maxTtl: Duration.seconds(200),
+      defaultTtl: Duration.seconds(150),
+    });
+    expect(testLambda.behavior).toMatchObject({
+      allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
+      compress: true,
+      isDefaultBehavior: true,
+      pathPattern: '/public/',
+      lambdaFunctionAssociations: [
+        {
+          eventType: LambdaEdgeEventType.ORIGIN_REQUEST,
+          lambdaFunction: testLambda.function.currentVersion,
+        },
+      ],
+      minTtl: Duration.seconds(100),
+      maxTtl: Duration.seconds(200),
+      defaultTtl: Duration.seconds(150),
+    });
+    expectCDK(stack).to(
+      haveResourceLike('AWS::Lambda::Function', {
+        Description: 'My transclusion lambda for my fancy stack.',
+        Handler: 'handler.handler',
+        Runtime: 'nodejs12.x',
+        Timeout: 123,
+      }),
+    );
+  });
+});

--- a/tests/edge-lambdas/transclusionLambda/index.test.ts
+++ b/tests/edge-lambdas/transclusionLambda/index.test.ts
@@ -1,38 +1,79 @@
 import { expect as expectCDK, haveResourceLike } from '@aws-cdk/assert';
 import { CloudFrontAllowedMethods, LambdaEdgeEventType } from '@aws-cdk/aws-cloudfront';
+import { Bucket } from '@aws-cdk/aws-s3';
 import { Stack, Duration } from '@aws-cdk/core';
 import { TransclusionLambda } from '../../../src/edge-lambdas/transclusionLambda';
 
 describe('TransclusionLambda', () => {
-  test('creates lambda function with default props', () => {
+  describe('with default props', () => {
     const stack = new Stack();
+    const testBucket = new Bucket(stack, 'Bucket');
     const testLambda = new TransclusionLambda(stack, 'Lambda', {
       isDefaultBehavior: false,
+      originBucket: testBucket,
     });
-    expect(testLambda.behavior).toMatchObject({
-      allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
-      compress: true,
-      isDefaultBehavior: false,
-      pathPattern: '*.shtml',
-      lambdaFunctionAssociations: [
-        {
-          eventType: LambdaEdgeEventType.ORIGIN_REQUEST,
-          lambdaFunction: testLambda.function.currentVersion,
-        },
-      ],
+
+    test('creates function', () => {
+      expectCDK(stack).to(
+        haveResourceLike('AWS::Lambda::Function', {
+          Description: 'Handles includes inside shtml files so we can serve them up correctly.',
+          Handler: 'handler.handler',
+          Runtime: 'nodejs12.x',
+          Timeout: 10,
+        }),
+      );
     });
-    expectCDK(stack).to(
-      haveResourceLike('AWS::Lambda::Function', {
-        Description: 'Handles includes inside shtml files so we can serve them up correctly.',
-        Handler: 'handler.handler',
-        Runtime: 'nodejs12.x',
-        Timeout: 10,
-      }),
-    );
+
+    test('creates valid behavior configuration', () => {
+      expect(testLambda.behavior).toMatchObject({
+        allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
+        compress: true,
+        isDefaultBehavior: false,
+        pathPattern: '*.shtml',
+        lambdaFunctionAssociations: [
+          {
+            eventType: LambdaEdgeEventType.ORIGIN_REQUEST,
+            lambdaFunction: testLambda.function.currentVersion,
+          },
+        ],
+      });
+    });
+
+    test('grants bucket read permissions to the lambda execution role', () => {
+      expectCDK(stack).to(
+        haveResourceLike('AWS::IAM::Policy', {
+          PolicyDocument: {
+            Statement: [
+              {
+                Action: 's3:GetObject*',
+                Effect: 'Allow',
+                Resource: {
+                  'Fn::Join': [
+                    '',
+                    [
+                      {
+                        'Fn::GetAtt': ['Bucket83908E77', 'Arn'],
+                      },
+                      '/*',
+                    ],
+                  ],
+                },
+              },
+            ],
+          },
+          Roles: [
+            {
+              Ref: 'LambdaFunctionServiceRoleC555A460',
+            },
+          ],
+        }),
+      );
+    });
   });
 
-  test('creates lambda function with overridden props', () => {
+  describe('with overridden props', () => {
     const stack = new Stack();
+    const testBucket = new Bucket(stack, 'Bucket');
     const testLambda = new TransclusionLambda(stack, 'Lambda', {
       description: 'My transclusion lambda for my fancy stack.',
       timeout: Duration.seconds(123),
@@ -41,29 +82,36 @@ describe('TransclusionLambda', () => {
       minTtl: Duration.seconds(100),
       maxTtl: Duration.seconds(200),
       defaultTtl: Duration.seconds(150),
+      originBucket: testBucket,
     });
-    expect(testLambda.behavior).toMatchObject({
-      allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
-      compress: true,
-      isDefaultBehavior: true,
-      pathPattern: '/public/',
-      lambdaFunctionAssociations: [
-        {
-          eventType: LambdaEdgeEventType.ORIGIN_REQUEST,
-          lambdaFunction: testLambda.function.currentVersion,
-        },
-      ],
-      minTtl: Duration.seconds(100),
-      maxTtl: Duration.seconds(200),
-      defaultTtl: Duration.seconds(150),
+
+    test('overrides defaults on function', () => {
+      expectCDK(stack).to(
+        haveResourceLike('AWS::Lambda::Function', {
+          Description: 'My transclusion lambda for my fancy stack.',
+          Handler: 'handler.handler',
+          Runtime: 'nodejs12.x',
+          Timeout: 123,
+        }),
+      );
     });
-    expectCDK(stack).to(
-      haveResourceLike('AWS::Lambda::Function', {
-        Description: 'My transclusion lambda for my fancy stack.',
-        Handler: 'handler.handler',
-        Runtime: 'nodejs12.x',
-        Timeout: 123,
-      }),
-    );
+
+    test('overrides defaults on behavior', () => {
+      expect(testLambda.behavior).toMatchObject({
+        allowedMethods: CloudFrontAllowedMethods.GET_HEAD_OPTIONS,
+        compress: true,
+        isDefaultBehavior: true,
+        pathPattern: '/public/',
+        lambdaFunctionAssociations: [
+          {
+            eventType: LambdaEdgeEventType.ORIGIN_REQUEST,
+            lambdaFunction: testLambda.function.currentVersion,
+          },
+        ],
+        minTtl: Duration.seconds(100),
+        maxTtl: Duration.seconds(200),
+        defaultTtl: Duration.seconds(150),
+      });
+    });
   });
 });


### PR DESCRIPTION
This adds 2 edge lambdas which can be reused in multiple projects. Including them as constructs allows us to define specific properties (passed as environment variables) that the lambda code depends on, in essence allowing for variation without duplicating code.