### PR TITLE
Add NewmanRunner construct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,3 +256,29 @@ const project = new Project(stack, `test-project`, {
   },
 });
 ```
+
+## Newman Runner
+
+This construct creates a CodeBuild project and an action which can be used in a pipeline to run newman tests. This is typically used for smoke tests to verify the service deployed by the pipeline is operational.
+
+Example usage:
+
+```typescript
+import { Pipeline } from '@aws-cdk/aws-codepipeline';
+import { Stack } from '@aws-cdk/core';
+import { NewmanPipelineProject } from '@ndlib/ndlib-cdk';
+
+const stack = new Stack();
+const pipeline = Pipeline(stack, 'MyPipeline');
+const newmanRunner = new NewmanRunner(stack, 'TestProject', {
+  collectionPath: 'test/newman/collection.json',
+  variables: {
+    hostname: 'https://www.example.com',
+    foo: 'bar',
+  },
+});
+pipeline.addStage({
+  stageName: 'Build',
+  actions: [buildAction, newmanRunner.action, approvalAction],
+});
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -215,6 +215,24 @@
         "constructs": "^3.2.0"
       }
     },
+    "@aws-cdk/aws-codedeploy": {
+      "version": "1.91.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codedeploy/-/aws-codedeploy-1.91.0.tgz",
+      "integrity": "sha512-vu92GsDA0tT40TVPqcqc1bFB0ef7jCxxWOe5wqMvzqiqEpy3fTjLY6Ia/8TopPCw/MGAnFEjPIFYyfF3xrRxmg==",
+      "requires": {
+        "@aws-cdk/aws-autoscaling": "1.91.0",
+        "@aws-cdk/aws-cloudwatch": "1.91.0",
+        "@aws-cdk/aws-ec2": "1.91.0",
+        "@aws-cdk/aws-elasticloadbalancing": "1.91.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.91.0",
+        "@aws-cdk/aws-iam": "1.91.0",
+        "@aws-cdk/aws-lambda": "1.91.0",
+        "@aws-cdk/aws-s3": "1.91.0",
+        "@aws-cdk/core": "1.91.0",
+        "@aws-cdk/custom-resources": "1.91.0",
+        "constructs": "^3.2.0"
+      }
+    },
     "@aws-cdk/aws-codeguruprofiler": {
       "version": "1.91.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.91.0.tgz",
@@ -236,6 +254,39 @@
         "@aws-cdk/aws-s3": "1.91.0",
         "@aws-cdk/core": "1.91.0",
         "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-codepipeline-actions": {
+      "version": "1.91.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline-actions/-/aws-codepipeline-actions-1.91.0.tgz",
+      "integrity": "sha512-8K7fUC1gGBObTMsGos/l016p0Kd2smav14vaJ+my8RYntPSJSZM9qezBLj6/gI+I0yAtzHciUG1JU1ZFwoodjA==",
+      "requires": {
+        "@aws-cdk/aws-cloudformation": "1.91.0",
+        "@aws-cdk/aws-codebuild": "1.91.0",
+        "@aws-cdk/aws-codecommit": "1.91.0",
+        "@aws-cdk/aws-codedeploy": "1.91.0",
+        "@aws-cdk/aws-codepipeline": "1.91.0",
+        "@aws-cdk/aws-ec2": "1.91.0",
+        "@aws-cdk/aws-ecr": "1.91.0",
+        "@aws-cdk/aws-ecs": "1.91.0",
+        "@aws-cdk/aws-events": "1.91.0",
+        "@aws-cdk/aws-events-targets": "1.91.0",
+        "@aws-cdk/aws-iam": "1.91.0",
+        "@aws-cdk/aws-lambda": "1.91.0",
+        "@aws-cdk/aws-s3": "1.91.0",
+        "@aws-cdk/aws-servicecatalog": "1.91.0",
+        "@aws-cdk/aws-sns": "1.91.0",
+        "@aws-cdk/aws-sns-subscriptions": "1.91.0",
+        "@aws-cdk/aws-stepfunctions": "1.91.0",
+        "@aws-cdk/core": "1.91.0",
+        "case": "1.6.3",
+        "constructs": "^3.2.0"
+      },
+      "dependencies": {
+        "case": {
+          "version": "1.6.3",
+          "bundled": true
+        }
       }
     },
     "@aws-cdk/aws-cognito": {
@@ -598,6 +649,15 @@
         "@aws-cdk/aws-sam": "1.91.0",
         "@aws-cdk/core": "1.91.0",
         "@aws-cdk/cx-api": "1.91.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-servicecatalog": {
+      "version": "1.91.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicecatalog/-/aws-servicecatalog-1.91.0.tgz",
+      "integrity": "sha512-mxfBT6FIU1O8hoRmf7uEV3IS1OKSgJdGDHESkFshr/M13fiIDdlrjUgzy7ZCk+IOMY7S/gkdmvLtrTB5fR1wmg==",
+      "requires": {
+        "@aws-cdk/core": "1.91.0",
         "constructs": "^3.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@aws-cdk/aws-cloudformation": "^1.45.0",
     "@aws-cdk/aws-cloudwatch": "^1.45.0",
     "@aws-cdk/aws-codepipeline": "^1.45.0",
+    "@aws-cdk/aws-codepipeline-actions": "^1.91.0",
     "@aws-cdk/aws-elasticloadbalancingv2": "^1.45.0",
     "@aws-cdk/aws-events-targets": "^1.45.0",
     "@aws-cdk/aws-sns": "^1.45.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export * from './slos/alarms-dashboard';
 export * from './slos/performance-dashboard';
 export * from './artifact-bucket';
 export * from './docker-codebuild-action';
+export * from './newman-runner';

--- a/src/newman-runner.ts
+++ b/src/newman-runner.ts
@@ -23,7 +23,7 @@ export interface INewmanRunnerProps extends PipelineProjectProps {
   };
 
   /**
-   * Display name for the action in a CodePipeline.
+   * Display name for the action in a CodePipeline. Defaults to construct id.
    */
   readonly actionName?: string;
 
@@ -34,6 +34,8 @@ export interface INewmanRunnerProps extends PipelineProjectProps {
 
   /**
    * Role that should run the CodeBuild Project.
+   * If omitted, a default service role may be created for the project. See AWS CDK documentation:
+   * https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-codebuild.PipelineProject.html#role
    */
   readonly role?: Role;
 }

--- a/src/newman-runner.ts
+++ b/src/newman-runner.ts
@@ -1,0 +1,89 @@
+import { BuildSpec, LinuxBuildImage, PipelineProject, PipelineProjectProps } from '@aws-cdk/aws-codebuild';
+import { Artifact } from '@aws-cdk/aws-codepipeline';
+import { CodeBuildAction } from '@aws-cdk/aws-codepipeline-actions';
+import { Role } from '@aws-cdk/aws-iam';
+import { Construct } from '@aws-cdk/core';
+
+export interface INewmanRunnerProps extends PipelineProjectProps {
+  /**
+   * The artifact which contains the newman collection file.
+   */
+  readonly sourceArtifact: Artifact;
+
+  /**
+   * Path to the newman collection file the project should execute.
+   */
+  readonly collectionPath: string;
+
+  /**
+   * Key-value pairs of environment variables to pass to the collection runner.
+   */
+  readonly collectionVariables: {
+    [key: string]: string;
+  };
+
+  /**
+   * Display name for the action in a CodePipeline.
+   */
+  readonly actionName?: string;
+
+  /**
+   * Order in the pipeline stage when this action should take place. Defaults to 98 so that approval can come after.
+   */
+  readonly runOrder?: number;
+
+  /**
+   * Role that should run the CodeBuild Project.
+   */
+  readonly role?: Role;
+}
+
+export class NewmanRunner {
+  /**
+   * CodeBuild project that will execute the newman collection.
+   */
+  public readonly project: PipelineProject;
+
+  /**
+   * Action to be included in a CodePipeline stage.
+   */
+  public readonly action: CodeBuildAction;
+
+  constructor(scope: Construct, id: string, props: INewmanRunnerProps) {
+    const environmentVars = Object.entries(props.collectionVariables).map(pair => `--env-var ${pair[0]}="${pair[1]}"`);
+    const projectProps = {
+      ...props,
+      environment: {
+        buildImage: LinuxBuildImage.STANDARD_5_0,
+      },
+      buildSpec: BuildSpec.fromObject({
+        version: '0.2',
+        phases: {
+          install: {
+            'runtime-versions': {
+              nodejs: '14.x',
+            },
+            commands: [
+              'npm install -g newman@5.2.2',
+              'echo "Ensure that the Newman spec is readable"',
+              `chmod 755 ${props.collectionPath}`,
+            ],
+          },
+          build: {
+            commands: [`newman run ${props.collectionPath} ${environmentVars.join(' ')}`],
+          },
+        },
+      }),
+    };
+    this.project = new PipelineProject(scope, id, projectProps);
+
+    this.action = new CodeBuildAction({
+      input: props.sourceArtifact,
+      project: this.project,
+      actionName: props.actionName || id,
+      runOrder: props.runOrder ?? 98,
+    });
+  }
+}
+
+export default NewmanRunner;

--- a/tests/newman-runner.test.ts
+++ b/tests/newman-runner.test.ts
@@ -1,0 +1,119 @@
+import { expect as expectCDK, haveResourceLike } from '@aws-cdk/assert';
+import { Artifact, Pipeline } from '@aws-cdk/aws-codepipeline';
+import { Role, ServicePrincipal } from '@aws-cdk/aws-iam';
+import { Stack } from '@aws-cdk/core';
+import { NewmanRunner } from '../src';
+import { FakeSourceAction } from './fake-source-action';
+
+describe('NewmanRunner', () => {
+  test('does not error with minimal props', () => {
+    const stack = new Stack();
+    new NewmanRunner(stack, 'TestProject', {
+      sourceArtifact: new Artifact(),
+      collectionPath: 'collection.json',
+      collectionVariables: {},
+    });
+    expectCDK(stack).to(
+      haveResourceLike('AWS::CodeBuild::Project', {
+        Source: {
+          BuildSpec:
+            '{\n  "version": "0.2",\n  "phases": {\n    "install": {\n      "runtime-versions": {\n        "nodejs": "14.x"\n      },\n      "commands": [\n        "npm install -g newman@5.2.2",\n        "echo \\"Ensure that the Newman spec is readable\\"",\n        "chmod 755 collection.json"\n      ]\n    },\n    "build": {\n      "commands": [\n        "newman run collection.json "\n      ]\n    }\n  }\n}',
+          Type: 'CODEPIPELINE',
+        },
+      }),
+    );
+  });
+
+  describe('with more props', () => {
+    const stack = new Stack();
+    const sourceArtifact = new Artifact();
+    const pipeline = new Pipeline(stack, 'CodePipeline', {
+      stages: [
+        {
+          stageName: 'Source',
+          actions: [
+            new FakeSourceAction({
+              actionName: 'Source',
+              output: sourceArtifact,
+            }),
+          ],
+        },
+      ],
+    });
+
+    const newmanRunner = new NewmanRunner(stack, 'TestProject', {
+      sourceArtifact: sourceArtifact,
+      collectionPath: 'test/newman/collection.json',
+      collectionVariables: {
+        hostname: 'https://www.example.com',
+        foo: 'bar',
+      },
+      actionName: 'MySmokeTestAction',
+      runOrder: 90,
+      role: new Role(stack, 'ExampleRole', {
+        assumedBy: new ServicePrincipal('codebuild.amazonaws.com'),
+      }),
+    });
+    pipeline.addStage({
+      stageName: 'Stage',
+      actions: [newmanRunner.action],
+    });
+
+    test('creates a codebuild project with props', () => {
+      expectCDK(stack).to(
+        haveResourceLike('AWS::CodeBuild::Project', {
+          Environment: {
+            Image: 'aws/codebuild/standard:5.0',
+          },
+          ServiceRole: {
+            'Fn::GetAtt': ['ExampleRole576372CE', 'Arn'],
+          },
+          Source: {
+            BuildSpec:
+              '{\n  "version": "0.2",\n  "phases": {\n    "install": {\n      "runtime-versions": {\n        "nodejs": "14.x"\n      },\n      "commands": [\n        "npm install -g newman@5.2.2",\n        "echo \\"Ensure that the Newman spec is readable\\"",\n        "chmod 755 test/newman/collection.json"\n      ]\n    },\n    "build": {\n      "commands": [\n        "newman run test/newman/collection.json --env-var hostname=\\"https://www.example.com\\" --env-var foo=\\"bar\\""\n      ]\n    }\n  }\n}',
+            Type: 'CODEPIPELINE',
+          },
+        }),
+      );
+    });
+
+    test('creates an action for the codebuild project in a pipeline', () => {
+      expectCDK(stack).to(
+        haveResourceLike('AWS::CodePipeline::Pipeline', {
+          Stages: [
+            {
+              Actions: [
+                {
+                  ActionTypeId: {
+                    Category: 'Source',
+                    Owner: 'AWS',
+                    Provider: 'Fake',
+                  },
+                  Name: 'Source',
+                },
+              ],
+            },
+            {
+              Actions: [
+                {
+                  ActionTypeId: {
+                    Category: 'Build',
+                    Owner: 'AWS',
+                    Provider: 'CodeBuild',
+                  },
+                  Configuration: {
+                    ProjectName: {
+                      Ref: 'TestProject2F1D5F9F',
+                    },
+                  },
+                  Name: 'MySmokeTestAction',
+                  RunOrder: 90,
+                },
+              ],
+            },
+          ],
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Running a newman collection is a very common way of doing smoke tests in our pipelines, and the codebuild project for doing so is going to be largely identical from project to project. Thus, it makes sense to standardize it here, with the option to pass whatever variables you want for your specific collection.

I debated whether this should include just the project or both the project and action. Currently, I don't see a use case outside of a CodePipeline for us, so I decided to include the action since that slightly simplifies the consumption of this construct.

I also debated what to name this. At first it was "NewmanPipelineProject", then "NewmanAction", but finally I went with NewmanRunner since I liked the way it read when accessing the properties:
`NewmanRunner.action`
`NewmanRunner.project`

This way it avoids redundancy and doesn't give the impression of only being one or the other, since it in fact has both a project and action.