### PR TITLE
feat(slo): Add CustomAvailability and CustomLatency SLOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,22 @@ const slos = [
     sloThreshold: 0.99,
     latencyThreshold: 100,
   },
+  {
+    type: 'CustomAvailability',
+    namespace: 'CustomNamespace',
+    errorsMetricName: 'CustomErrorCountMetric',
+    countsMetricName: 'CustomRequestCountMetric',
+    title: 'My Custom Availability',
+    sloThreshold: 0.99,
+  },
+  {
+    type: 'CustomLatency',
+    namespace: 'CustomNamespace',
+    latencyMetricName: 'CustomLatencyMetric',
+    title: 'My Custom Latency',
+    sloThreshold: 0.99,
+    latencyThreshold: 2000,
+  },
 ];
 const stack = new cdk.Stack();
 

--- a/src/slos/alarms-dashboard.ts
+++ b/src/slos/alarms-dashboard.ts
@@ -4,6 +4,8 @@ import { ApiAvailabilityWidget } from './api-availability-widget';
 import { ApiLatencyWidget } from './api-latency-widget';
 import { CloudfrontAvailabilityWidget } from './cloudfront-availability-widget';
 import { CloudfrontLatencyWidget } from './cloudfront-latency-widget';
+import { CustomAvailabilityWidget } from './custom-availability-widget';
+import { CustomLatencyWidget } from './custom-latency-widget';
 import { ElasticSearchAvailabilityWidget } from './elasticsearch-availability-widget';
 import { ElasticSearchLatencyWidget } from './elasticsearch-latency-widget';
 import {
@@ -12,10 +14,13 @@ import {
   ApiLatencySLO,
   CloudfrontAvailabilitySLO,
   CloudfrontLatencySLO,
+  CustomAvailabilitySLO,
+  CustomLatencySLO,
   ElasticSearchAvailabilitySLO,
   ElasticSearchLatencySLO,
   IAlertConfig,
 } from './types';
+
 import { Windows } from './windows';
 
 export interface ISLOAlarmsDashboardProps extends DashboardProps {
@@ -82,6 +87,31 @@ export class SLOAlarmsDashboard extends Dashboard {
     );
   };
 
+  // Creates an array of CustomAvailabilityWidgets for each window we are using
+  public static customAvailabilityAlarmsRow = (windows: IAlertConfig[], slo: CustomAvailabilitySLO) => {
+    return windows.map(
+      sloWindow =>
+        new CustomAvailabilityWidget({
+          ...slo,
+          sloWindow,
+          showBurnRateThreshold: true,
+          addPeriodToTitle: true,
+        }),
+    );
+  };
+
+  // Creates an array of ApiLatencyWidgets for each window we are using
+  public static customLatencyAlarmsRow = (windows: IAlertConfig[], slo: CustomLatencySLO) => {
+    return windows.map(
+      sloWindow =>
+        new CustomLatencyWidget({
+          ...slo,
+          sloWindow,
+          showBurnRateThreshold: true,
+          addPeriodToTitle: true,
+        }),
+    );
+  };
   // Creates an array of ElasticSearchAvailabilityWidgets for each window we are using
   public static elasticSearchAvailabilityAlarmsRow = (windows: IAlertConfig[], slo: ElasticSearchAvailabilitySLO) => {
     return windows.map(
@@ -125,6 +155,12 @@ export class SLOAlarmsDashboard extends Dashboard {
           break;
         case 'CloudfrontLatency':
           result.push(SLOAlarmsDashboard.cloudfrontLatencyAlarmsRow(windows, slo as CloudfrontLatencySLO));
+          break;
+        case 'CustomAvailability':
+          result.push(SLOAlarmsDashboard.customAvailabilityAlarmsRow(windows, slo as CustomAvailabilitySLO));
+          break;
+        case 'CustomLatency':
+          result.push(SLOAlarmsDashboard.customLatencyAlarmsRow(windows, slo as CustomLatencySLO));
           break;
         case 'ElasticSearchAvailability':
           result.push(

--- a/src/slos/custom-availability-metric.ts
+++ b/src/slos/custom-availability-metric.ts
@@ -1,0 +1,55 @@
+import { MathExpression, Metric } from '@aws-cdk/aws-cloudwatch';
+import { IAlertConfig } from './types';
+
+export interface ICustomAvailabilityMetricProps {
+  /**
+   * The custom namespace to find the errors and requests metrics
+   */
+  readonly namespace: string;
+
+  /**
+   * The custom metric name that will give the count of 5xx errors
+   */
+  readonly errorsMetricName: string;
+
+  /**
+   * The custom metric name that will give the count of requests
+   */
+  readonly countsMetricName: string;
+
+  /**
+   * The SLO window that this metric will be used for.
+   */
+  readonly sloWindow: IAlertConfig;
+}
+
+/**
+ * Creates a metric that can be used as an SLI for Custom Metrics
+ * Availability SLOs
+ */
+export class CustomAvailabilityMetric extends MathExpression {
+  constructor(props: ICustomAvailabilityMetricProps) {
+    const errors = new Metric({
+      namespace: props.namespace,
+      metricName: props.errorsMetricName,
+      statistic: 'Sum',
+      label: 'Errors',
+    });
+
+    const requests = new Metric({
+      namespace: props.namespace,
+      metricName: props.countsMetricName,
+      statistic: 'Sum',
+      label: 'Requests',
+    });
+
+    const myProps = {
+      label: 'Availability',
+      expression: '(requests - errors)/requests',
+      usingMetrics: { requests, errors },
+      period: props.sloWindow.alertWindow,
+    };
+
+    super({ ...props, ...myProps });
+  }
+}

--- a/src/slos/custom-availability-widget.ts
+++ b/src/slos/custom-availability-widget.ts
@@ -1,0 +1,35 @@
+import { AvailabilityWidget } from './availability-widget';
+import { CustomAvailabilityMetric } from './custom-availability-metric';
+import { ISLOWidgetProps } from './types';
+
+export interface ICustomAvailabilityWidgetProps extends ISLOWidgetProps {
+  /**
+   * Name of the namespace for this metric
+   */
+  readonly namespace: string;
+
+  /**
+   * The custom metric name that will give the count of 5xx errors
+   */
+  readonly errorsMetricName: string;
+
+  /**
+   * The custom metric name that will give the count of requests
+   */
+  readonly countsMetricName: string;
+}
+
+/**
+ * Creates an availability widget using an API Gateway availability metric
+ */
+export class CustomAvailabilityWidget extends AvailabilityWidget {
+  constructor(props: ICustomAvailabilityWidgetProps) {
+    const availability = new CustomAvailabilityMetric({
+      namespace: props.namespace,
+      errorsMetricName: props.errorsMetricName,
+      countsMetricName: props.countsMetricName,
+      sloWindow: props.sloWindow,
+    });
+    super({ availability, ...props });
+  }
+}

--- a/src/slos/custom-latency-metric.ts
+++ b/src/slos/custom-latency-metric.ts
@@ -1,0 +1,45 @@
+import { Metric } from '@aws-cdk/aws-cloudwatch';
+import { IAlertConfig } from './types';
+
+export interface ICustomLatencyMetricProps {
+  /**
+   * The custom namespace to find the errors and requests metrics
+   */
+  readonly namespace: string;
+
+  /**
+   * The custom metric name that will give the count of 5xx errors
+   */
+  readonly latencyMetricName: string;
+
+  /**
+   * The SLO window that this metric will be used for.
+   */
+  readonly sloWindow: IAlertConfig;
+
+  /**
+   * The decimal value for the threshold of the SLO.
+   */
+  readonly sloThreshold: number;
+}
+
+/**
+ * Creates a metric that can be used as an SLI for API Gateway
+ * Latency SLOs
+ */
+export class CustomLatencyMetric extends Metric {
+  constructor(props: ICustomLatencyMetricProps) {
+    const sloBudget = 100 - props.sloThreshold * 100;
+    let alarmThreshold = 100 - props.sloWindow.burnRateThreshold * sloBudget;
+    alarmThreshold = Math.max(0, Math.min(alarmThreshold, 100));
+    const statistic = `p${alarmThreshold.toFixed(2)}`;
+    const myProps = {
+      namespace: props.namespace,
+      metricName: props.latencyMetricName,
+      statistic,
+      label: `Latency ${statistic}`,
+      period: props.sloWindow.alertWindow,
+    };
+    super({ ...props, ...myProps });
+  }
+}

--- a/src/slos/custom-latency-widget.ts
+++ b/src/slos/custom-latency-widget.ts
@@ -1,0 +1,35 @@
+import { CustomLatencyMetric } from './custom-latency-metric';
+import { LatencyWidget } from './latency-widget';
+import { ISLOWidgetProps } from './types';
+
+export interface ICustomLatencyWidgetProps extends ISLOWidgetProps {
+  /**
+   * The custom namespace to find the errors and requests metrics
+   */
+  readonly namespace: string;
+
+  /**
+   * The custom metric name that will give the count of 5xx errors
+   */
+  readonly latencyMetricName: string;
+
+  /**
+   * The integer value for the latency threshold in ms.
+   */
+  readonly latencyThreshold: number;
+}
+
+/**
+ * Creates a latency widget using a Custom latency metric
+ */
+export class CustomLatencyWidget extends LatencyWidget {
+  constructor(props: ICustomLatencyWidgetProps) {
+    const latency = new CustomLatencyMetric({
+      namespace: props.namespace,
+      latencyMetricName: props.latencyMetricName,
+      sloThreshold: props.sloThreshold,
+      sloWindow: props.sloWindow,
+    });
+    super({ latency, ...props });
+  }
+}

--- a/src/slos/performance-dashboard.ts
+++ b/src/slos/performance-dashboard.ts
@@ -4,6 +4,8 @@ import { ApiAvailabilityWidget } from './api-availability-widget';
 import { ApiLatencyWidget } from './api-latency-widget';
 import { CloudfrontAvailabilityWidget } from './cloudfront-availability-widget';
 import { CloudfrontLatencyWidget } from './cloudfront-latency-widget';
+import { CustomAvailabilityWidget } from './custom-availability-widget';
+import { CustomLatencyWidget } from './custom-latency-widget';
 import { ElasticSearchAvailabilityWidget } from './elasticsearch-availability-widget';
 import { ElasticSearchLatencyWidget } from './elasticsearch-latency-widget';
 import {
@@ -12,6 +14,8 @@ import {
   ApiLatencySLO,
   CloudfrontAvailabilitySLO,
   CloudfrontLatencySLO,
+  CustomAvailabilitySLO,
+  CustomLatencySLO,
   ElasticSearchAvailabilitySLO,
   ElasticSearchLatencySLO,
 } from './types';
@@ -77,6 +81,26 @@ export class SLOPerformanceDashboard extends Dashboard {
                 ...cloudfrontLatencySlo,
                 sloWindow: Windows.thirtyDays,
                 title: `${cloudfrontLatencySlo.title} - Latency ${cloudfrontLatencySlo.latencyThreshold}ms`,
+              }),
+            );
+            break;
+          case 'CustomAvailability':
+            const customAvailabilitySlo = slo as CustomAvailabilitySLO;
+            lastRow.push(
+              new CustomAvailabilityWidget({
+                ...customAvailabilitySlo,
+                sloWindow: Windows.thirtyDays,
+                title: `${customAvailabilitySlo.title} - Availability`,
+              }),
+            );
+            break;
+          case 'CustomLatency':
+            const customLatencySlo = slo as CustomLatencySLO;
+            lastRow.push(
+              new CustomLatencyWidget({
+                ...customLatencySlo,
+                sloWindow: Windows.thirtyDays,
+                title: `${customLatencySlo.title} - Latency ${customLatencySlo.latencyThreshold}ms`,
               }),
             );
             break;

--- a/src/slos/types.ts
+++ b/src/slos/types.ts
@@ -69,6 +69,23 @@ export interface IElasticSearchSLI {
   readonly domainName: string;
 }
 
+/**
+ * Properties specific to Custom Availability Metric based Service Level Indicators
+ */
+export interface ICustomAvailibilitySLI {
+  readonly namespace: string;
+  readonly errorsMetricName: string;
+  readonly countsMetricName: string;
+}
+
+/**
+ * Properties specific to Custom Latency Metric based Service Level Indicators
+ */
+export interface ICustomLatencySLI {
+  readonly namespace: string;
+  readonly latencyMetricName: string;
+}
+
 // SLO types are combinations of the objective and the indicator
 export type ApiAvailabilitySLO = IAvailabilitySLO & IApiSLI;
 export type ApiLatencySLO = ILatencySLO & IApiSLI;
@@ -76,13 +93,17 @@ export type CloudfrontAvailabilitySLO = IAvailabilitySLO & ICloudfrontSLI;
 export type CloudfrontLatencySLO = ILatencySLO & ICloudfrontSLI;
 export type ElasticSearchAvailabilitySLO = IAvailabilitySLO & IElasticSearchSLI;
 export type ElasticSearchLatencySLO = ILatencySLO & IElasticSearchSLI;
+export type CustomAvailabilitySLO = IAvailabilitySLO & ICustomAvailibilitySLI;
+export type CustomLatencySLO = ILatencySLO & ICustomLatencySLI;
 export type AnySLO =
   | ApiAvailabilitySLO
   | ApiLatencySLO
   | CloudfrontAvailabilitySLO
   | CloudfrontLatencySLO
   | ElasticSearchAvailabilitySLO
-  | ElasticSearchLatencySLO;
+  | ElasticSearchLatencySLO
+  | CustomAvailabilitySLO
+  | CustomLatencySLO;
 
 /**
  * Defines a configuration for alerting on burn rates within a window

--- a/tests/slos/alarms-dashboard.test.ts
+++ b/tests/slos/alarms-dashboard.test.ts
@@ -1,11 +1,12 @@
-import { expect as cdkExpect, haveResourceLike } from '@aws-cdk/assert';
+import { Capture, expect as cdkExpect, haveResourceLike } from '@aws-cdk/assert';
 import { SLOAlarmsDashboard } from '../../src/slos/alarms-dashboard';
 import { Stack } from '@aws-cdk/core';
+import { collapseJoin } from './helpers';
 
 describe('SLOAlarmsDashboard', () => {
   const invalidSlos = [{ type: 'SomeUndefined', apiName: 'apiName', title: 'My Made Up SLO', sloThreshold: 0.999 }];
 
-  it('throws an excpetion if theres an unknown type', () => {
+  it('throws an exception if theres an unknown type', () => {
     const stack = new Stack();
     expect(() => new SLOAlarmsDashboard(stack, 'TestAlarmsDashboard', { slos: invalidSlos })).toThrow(
       'AlarmsDashboard creation encountered an unknown type for slo: {"type":"SomeUndefined","apiName":"apiName","title":"My Made Up SLO","sloThreshold":0.999}.',
@@ -27,34 +28,17 @@ describe('SLOAlarmsDashboard', () => {
       dashboardName: 'TestAlarmsDashboard',
       start: '-P1234D',
     });
-
+    const dashBody = Capture.anyType();
     cdkExpect(stack).to(
       haveResourceLike('AWS::CloudWatch::Dashboard', {
-        DashboardBody: {
-          'Fn::Join': [
-            '',
-            [
-              '{"start":"-P1234D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 60 minutes","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":3600,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"2% of Budget in 60 minutes","value":0.9856,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.98272,"max":1}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 6 hours","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":21600,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"5% of Budget in 6 hours","value":0.994,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9928,"max":1}}}},{"type":"metric","width":6,"height":6,"x":12,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 1 day","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":86400,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"10% of Budget in 1 day","value":0.999,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9988,"max":1}}}},{"type":"metric","width":6,"height":6,"x":18,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 30 days","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":2592000,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"100% of Budget in 30 days","value":0.999,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9988,"max":1}}}}]}',
-            ],
-          ],
-        },
+        DashboardBody: dashBody.capture(),
         DashboardName: 'TestAlarmsDashboard',
+      }),
+    );
+    const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+    expect(dashObj).toEqual(
+      expect.objectContaining({
+        start: '-P1234D',
       }),
     );
   });
@@ -72,34 +56,86 @@ describe('SLOAlarmsDashboard', () => {
     it('constructs a dashboard with all four windows: 2%, 5%, 10%, and 100%', () => {
       const stack = new Stack();
       new SLOAlarmsDashboard(stack, 'TestAlarmsDashboard', { slos, dashboardName: 'TestAlarmsDashboard' });
-
+      const dashBody = Capture.anyType();
       cdkExpect(stack).to(
         haveResourceLike('AWS::CloudWatch::Dashboard', {
-          DashboardBody: {
-            'Fn::Join': [
-              '',
-              [
-                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 60 minutes","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":3600,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"2% of Budget in 60 minutes","value":0.9856,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.98272,"max":1}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 6 hours","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":21600,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"5% of Budget in 6 hours","value":0.994,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9928,"max":1}}}},{"type":"metric","width":6,"height":6,"x":12,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 1 day","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":86400,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"10% of Budget in 1 day","value":0.999,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9988,"max":1}}}},{"type":"metric","width":6,"height":6,"x":18,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 30 days","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":2592000,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"100% of Budget in 30 days","value":0.999,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.999,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9988,"max":1}}}}]}',
-              ],
-            ],
-          },
+          DashboardBody: dashBody.capture(),
           DashboardName: 'TestAlarmsDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My Cloudfront - 60 minutes`,
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '1-(errorRate/100)' }],
+                  [
+                    'AWS/CloudFront',
+                    '5xxErrorRate',
+                    'DistributionId',
+                    'myDistributionId',
+                    'Region',
+                    'Global',
+                    { label: 'Error rate', period: 3600, visible: false, id: 'errorRate' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My Cloudfront - 6 hours',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '1-(errorRate/100)' }],
+                  [
+                    'AWS/CloudFront',
+                    '5xxErrorRate',
+                    'DistributionId',
+                    'myDistributionId',
+                    'Region',
+                    'Global',
+                    { label: 'Error rate', period: 21600, visible: false, id: 'errorRate' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My Cloudfront - 1 day',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '1-(errorRate/100)' }],
+                  [
+                    'AWS/CloudFront',
+                    '5xxErrorRate',
+                    'DistributionId',
+                    'myDistributionId',
+                    'Region',
+                    'Global',
+                    { label: 'Error rate', period: 86400, visible: false, id: 'errorRate' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My Cloudfront - 30 days',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '1-(errorRate/100)' }],
+                  [
+                    'AWS/CloudFront',
+                    '5xxErrorRate',
+                    'DistributionId',
+                    'myDistributionId',
+                    'Region',
+                    'Global',
+                    { label: 'Error rate', period: 2592000, visible: false, id: 'errorRate' },
+                  ],
+                ]),
+              }),
+            }),
+          ]),
         }),
       );
     });
@@ -119,34 +155,82 @@ describe('SLOAlarmsDashboard', () => {
     it('constructs a dashboard with all four windows: 2%, 5%, 10%, and 100%', () => {
       const stack = new Stack();
       new SLOAlarmsDashboard(stack, 'TestAlarmsDashboard', { slos, dashboardName: 'TestAlarmsDashboard' });
-
+      const dashBody = Capture.anyType();
       cdkExpect(stack).to(
         haveResourceLike('AWS::CloudWatch::Dashboard', {
-          DashboardBody: {
-            'Fn::Join': [
-              '',
-              [
-                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 60 minutes","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[["AWS/CloudFront","OriginLatency","DistributionId","myDistributionId","Region","Global",{"label":"Latency p28.00","period":3600,"stat":"p28.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":200,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":280}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 6 hours","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[["AWS/CloudFront","OriginLatency","DistributionId","myDistributionId","Region","Global",{"label":"Latency p70.00","period":21600,"stat":"p70.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":200,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":280}}}},{"type":"metric","width":6,"height":6,"x":12,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 1 day","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[["AWS/CloudFront","OriginLatency","DistributionId","myDistributionId","Region","Global",{"label":"Latency p95.00","period":86400,"stat":"p95.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":200,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":280}}}},{"type":"metric","width":6,"height":6,"x":18,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - 30 days","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[["AWS/CloudFront","OriginLatency","DistributionId","myDistributionId","Region","Global",{"label":"Latency p95.00","period":2592000,"stat":"p95.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":200,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":280}}}}]}',
-              ],
-            ],
-          },
+          DashboardBody: dashBody.capture(),
           DashboardName: 'TestAlarmsDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My Cloudfront - 60 minutes`,
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/CloudFront',
+                    'OriginLatency',
+                    'DistributionId',
+                    'myDistributionId',
+                    'Region',
+                    'Global',
+                    { label: 'Latency p28.00', period: 3600, stat: 'p28.00' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My Cloudfront - 6 hours',
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/CloudFront',
+                    'OriginLatency',
+                    'DistributionId',
+                    'myDistributionId',
+                    'Region',
+                    'Global',
+                    { label: 'Latency p70.00', period: 21600, stat: 'p70.00' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My Cloudfront - 1 day',
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/CloudFront',
+                    'OriginLatency',
+                    'DistributionId',
+                    'myDistributionId',
+                    'Region',
+                    'Global',
+                    { label: 'Latency p95.00', period: 86400, stat: 'p95.00' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My Cloudfront - 30 days',
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/CloudFront',
+                    'OriginLatency',
+                    'DistributionId',
+                    'myDistributionId',
+                    'Region',
+                    'Global',
+                    { label: 'Latency p95.00', period: 2592000, stat: 'p95.00' },
+                  ],
+                ]),
+              }),
+            }),
+          ]),
         }),
       );
     });
@@ -158,34 +242,106 @@ describe('SLOAlarmsDashboard', () => {
     it('constructs a dashboard with all four windows: 2%, 5%, 10%, and 100%', () => {
       const stack = new Stack();
       new SLOAlarmsDashboard(stack, 'TestAlarmsDashboard', { slos, dashboardName: 'TestAlarmsDashboard' });
-
+      const dashBody = Capture.anyType();
       cdkExpect(stack).to(
         haveResourceLike('AWS::CloudWatch::Dashboard', {
-          DashboardBody: {
-            'Fn::Join': [
-              '',
-              [
-                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My API - 60 minutes","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[[{"label":"Availability","expression":"(gatewayRequests - gatewayErrors)/gatewayRequests"}],["AWS/ApiGateway","Count","ApiName","myApiName",{"label":"Requests","period":3600,"stat":"Sum","visible":false,"id":"gatewayRequests"}],["AWS/ApiGateway","5XXError","ApiName","myApiName",{"label":"Error rate","period":3600,"stat":"Sum","visible":false,"id":"gatewayErrors"}]],"annotations":{"horizontal":[{"label":"2% of Budget in 60 minutes","value":0.856,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.99,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.8271999999999998,"max":1}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My API - 6 hours","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[[{"label":"Availability","expression":"(gatewayRequests - gatewayErrors)/gatewayRequests"}],["AWS/ApiGateway","Count","ApiName","myApiName",{"label":"Requests","period":21600,"stat":"Sum","visible":false,"id":"gatewayRequests"}],["AWS/ApiGateway","5XXError","ApiName","myApiName",{"label":"Error rate","period":21600,"stat":"Sum","visible":false,"id":"gatewayErrors"}]],"annotations":{"horizontal":[{"label":"5% of Budget in 6 hours","value":0.94,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.99,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9279999999999999,"max":1}}}},{"type":"metric","width":6,"height":6,"x":12,"y":0,"properties":{"view":"timeSeries","title":"My API - 1 day","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[[{"label":"Availability","expression":"(gatewayRequests - gatewayErrors)/gatewayRequests"}],["AWS/ApiGateway","Count","ApiName","myApiName",{"label":"Requests","period":86400,"stat":"Sum","visible":false,"id":"gatewayRequests"}],["AWS/ApiGateway","5XXError","ApiName","myApiName",{"label":"Error rate","period":86400,"stat":"Sum","visible":false,"id":"gatewayErrors"}]],"annotations":{"horizontal":[{"label":"10% of Budget in 1 day","value":0.99,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.99,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.988,"max":1}}}},{"type":"metric","width":6,"height":6,"x":18,"y":0,"properties":{"view":"timeSeries","title":"My API - 30 days","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[[{"label":"Availability","expression":"(gatewayRequests - gatewayErrors)/gatewayRequests"}],["AWS/ApiGateway","Count","ApiName","myApiName",{"label":"Requests","period":2592000,"stat":"Sum","visible":false,"id":"gatewayRequests"}],["AWS/ApiGateway","5XXError","ApiName","myApiName",{"label":"Error rate","period":2592000,"stat":"Sum","visible":false,"id":"gatewayErrors"}]],"annotations":{"horizontal":[{"label":"100% of Budget in 30 days","value":0.99,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.99,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.988,"max":1}}}}]}',
-              ],
-            ],
-          },
+          DashboardBody: dashBody.capture(),
           DashboardName: 'TestAlarmsDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My API - 60 minutes`,
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(gatewayRequests - gatewayErrors)/gatewayRequests' }],
+                  [
+                    'AWS/ApiGateway',
+                    'Count',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Requests', period: 3600, stat: 'Sum', visible: false, id: 'gatewayRequests' },
+                  ],
+                  [
+                    'AWS/ApiGateway',
+                    '5XXError',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Error rate', period: 3600, stat: 'Sum', visible: false, id: 'gatewayErrors' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My API - 6 hours',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(gatewayRequests - gatewayErrors)/gatewayRequests' }],
+                  [
+                    'AWS/ApiGateway',
+                    'Count',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Requests', period: 21600, stat: 'Sum', visible: false, id: 'gatewayRequests' },
+                  ],
+                  [
+                    'AWS/ApiGateway',
+                    '5XXError',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Error rate', period: 21600, stat: 'Sum', visible: false, id: 'gatewayErrors' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My API - 1 day',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(gatewayRequests - gatewayErrors)/gatewayRequests' }],
+                  [
+                    'AWS/ApiGateway',
+                    'Count',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Requests', period: 86400, stat: 'Sum', visible: false, id: 'gatewayRequests' },
+                  ],
+                  [
+                    'AWS/ApiGateway',
+                    '5XXError',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Error rate', period: 86400, stat: 'Sum', visible: false, id: 'gatewayErrors' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My API - 30 days',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(gatewayRequests - gatewayErrors)/gatewayRequests' }],
+                  [
+                    'AWS/ApiGateway',
+                    'Count',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Requests', period: 2592000, stat: 'Sum', visible: false, id: 'gatewayRequests' },
+                  ],
+                  [
+                    'AWS/ApiGateway',
+                    '5XXError',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Error rate', period: 2592000, stat: 'Sum', visible: false, id: 'gatewayErrors' },
+                  ],
+                ]),
+              }),
+            }),
+          ]),
         }),
       );
     });
@@ -199,131 +355,559 @@ describe('SLOAlarmsDashboard', () => {
     it('constructs a dashboard with all four windows: 2%, 5%, 10%, and 100%', () => {
       const stack = new Stack();
       new SLOAlarmsDashboard(stack, 'TestAlarmsDashboard', { slos, dashboardName: 'TestAlarmsDashboard' });
-
+      const dashBody = Capture.anyType();
       cdkExpect(stack).to(
         haveResourceLike('AWS::CloudWatch::Dashboard', {
-          DashboardBody: {
-            'Fn::Join': [
-              '',
-              [
-                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My API - 60 minutes","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[["AWS/ApiGateway","Latency","ApiName","myApiName",{"label":"Latency p85.60","period":3600,"stat":"p85.60"}]],"annotations":{"horizontal":[{"label":"SLO","value":2000,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":2800}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My API - 6 hours","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[["AWS/ApiGateway","Latency","ApiName","myApiName",{"label":"Latency p94.00","period":21600,"stat":"p94.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":2000,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":2800}}}},{"type":"metric","width":6,"height":6,"x":12,"y":0,"properties":{"view":"timeSeries","title":"My API - 1 day","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[["AWS/ApiGateway","Latency","ApiName","myApiName",{"label":"Latency p99.00","period":86400,"stat":"p99.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":2000,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":2800}}}},{"type":"metric","width":6,"height":6,"x":18,"y":0,"properties":{"view":"timeSeries","title":"My API - 30 days","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[["AWS/ApiGateway","Latency","ApiName","myApiName",{"label":"Latency p99.00","period":2592000,"stat":"p99.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":2000,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":2800}}}}]}',
-              ],
-            ],
-          },
+          DashboardBody: dashBody.capture(),
           DashboardName: 'TestAlarmsDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My API - 60 minutes`,
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/ApiGateway',
+                    'Latency',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Latency p85.60', period: 3600, stat: 'p85.60' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My API - 6 hours',
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/ApiGateway',
+                    'Latency',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Latency p94.00', period: 21600, stat: 'p94.00' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My API - 1 day',
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/ApiGateway',
+                    'Latency',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Latency p99.00', period: 86400, stat: 'p99.00' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My API - 30 days',
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/ApiGateway',
+                    'Latency',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Latency p99.00', period: 2592000, stat: 'p99.00' },
+                  ],
+                ]),
+              }),
+            }),
+          ]),
         }),
       );
     });
   });
-});
 
-describe('ElasticSearchAvailability', () => {
-  const slos = [
-    {
-      type: 'ElasticSearchAvailability',
-      domainName: 'domainName',
-      accountId: 'accountId',
-      title: 'My ES Domain',
-      sloThreshold: 0.99,
-    },
-  ];
+  describe('ElasticSearchAvailability', () => {
+    const slos = [
+      {
+        type: 'ElasticSearchAvailability',
+        domainName: 'domainName',
+        accountId: 'accountId',
+        title: 'My ES Domain',
+        sloThreshold: 0.99,
+      },
+    ];
 
-  it('constructs a dashboard with all four windows: 2%, 5%, 10%, and 100%', () => {
-    const stack = new Stack();
-    new SLOAlarmsDashboard(stack, 'TestAlarmsDashboard', { slos, dashboardName: 'TestAlarmsDashboard' });
-
-    cdkExpect(stack).to(
-      haveResourceLike('AWS::CloudWatch::Dashboard', {
-        DashboardBody: {
-          'Fn::Join': [
-            '',
-            [
-              '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My ES Domain - 60 minutes","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[[{"label":"Availability","expression":"(m2xx + m3xx + m4xx)/(m2xx + m3xx + m4xx + m5xx)"}],["AWS/ES","2xx","ClientId","accountId","DomainName","domainName",{"label":"2xx","period":3600,"stat":"Sum","visible":false,"id":"m2xx"}],["AWS/ES","3xx","ClientId","accountId","DomainName","domainName",{"label":"3xx","period":3600,"stat":"Sum","visible":false,"id":"m3xx"}],["AWS/ES","4xx","ClientId","accountId","DomainName","domainName",{"label":"4xx","period":3600,"stat":"Sum","visible":false,"id":"m4xx"}],["AWS/ES","5xx","ClientId","accountId","DomainName","domainName",{"label":"5xx","period":3600,"stat":"Sum","visible":false,"id":"m5xx"}]],"annotations":{"horizontal":[{"label":"2% of Budget in 60 minutes","value":0.856,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.99,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.8271999999999998,"max":1}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My ES Domain - 6 hours","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[[{"label":"Availability","expression":"(m2xx + m3xx + m4xx)/(m2xx + m3xx + m4xx + m5xx)"}],["AWS/ES","2xx","ClientId","accountId","DomainName","domainName",{"label":"2xx","period":21600,"stat":"Sum","visible":false,"id":"m2xx"}],["AWS/ES","3xx","ClientId","accountId","DomainName","domainName",{"label":"3xx","period":21600,"stat":"Sum","visible":false,"id":"m3xx"}],["AWS/ES","4xx","ClientId","accountId","DomainName","domainName",{"label":"4xx","period":21600,"stat":"Sum","visible":false,"id":"m4xx"}],["AWS/ES","5xx","ClientId","accountId","DomainName","domainName",{"label":"5xx","period":21600,"stat":"Sum","visible":false,"id":"m5xx"}]],"annotations":{"horizontal":[{"label":"5% of Budget in 6 hours","value":0.94,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.99,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.9279999999999999,"max":1}}}},{"type":"metric","width":6,"height":6,"x":12,"y":0,"properties":{"view":"timeSeries","title":"My ES Domain - 1 day","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[[{"label":"Availability","expression":"(m2xx + m3xx + m4xx)/(m2xx + m3xx + m4xx + m5xx)"}],["AWS/ES","2xx","ClientId","accountId","DomainName","domainName",{"label":"2xx","period":86400,"stat":"Sum","visible":false,"id":"m2xx"}],["AWS/ES","3xx","ClientId","accountId","DomainName","domainName",{"label":"3xx","period":86400,"stat":"Sum","visible":false,"id":"m3xx"}],["AWS/ES","4xx","ClientId","accountId","DomainName","domainName",{"label":"4xx","period":86400,"stat":"Sum","visible":false,"id":"m4xx"}],["AWS/ES","5xx","ClientId","accountId","DomainName","domainName",{"label":"5xx","period":86400,"stat":"Sum","visible":false,"id":"m5xx"}]],"annotations":{"horizontal":[{"label":"10% of Budget in 1 day","value":0.99,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.99,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.988,"max":1}}}},{"type":"metric","width":6,"height":6,"x":18,"y":0,"properties":{"view":"timeSeries","title":"My ES Domain - 30 days","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[[{"label":"Availability","expression":"(m2xx + m3xx + m4xx)/(m2xx + m3xx + m4xx + m5xx)"}],["AWS/ES","2xx","ClientId","accountId","DomainName","domainName",{"label":"2xx","period":2592000,"stat":"Sum","visible":false,"id":"m2xx"}],["AWS/ES","3xx","ClientId","accountId","DomainName","domainName",{"label":"3xx","period":2592000,"stat":"Sum","visible":false,"id":"m3xx"}],["AWS/ES","4xx","ClientId","accountId","DomainName","domainName",{"label":"4xx","period":2592000,"stat":"Sum","visible":false,"id":"m4xx"}],["AWS/ES","5xx","ClientId","accountId","DomainName","domainName",{"label":"5xx","period":2592000,"stat":"Sum","visible":false,"id":"m5xx"}]],"annotations":{"horizontal":[{"label":"100% of Budget in 30 days","value":0.99,"fill":"below","color":"#d62728","yAxis":"left"},{"label":"SLO","value":0.99,"fill":"none","color":"#ff7f0e","yAxis":"left"}]},"yAxis":{"left":{"min":0.988,"max":1}}}}]}',
-            ],
-          ],
-        },
-        DashboardName: 'TestAlarmsDashboard',
-      }),
-    );
+    it('constructs a dashboard with all four windows: 2%, 5%, 10%, and 100%', () => {
+      const stack = new Stack();
+      new SLOAlarmsDashboard(stack, 'TestAlarmsDashboard', { slos, dashboardName: 'TestAlarmsDashboard' });
+      const dashBody = Capture.anyType();
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Dashboard', {
+          DashboardBody: dashBody.capture(),
+          DashboardName: 'TestAlarmsDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My ES Domain - 60 minutes`,
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(m2xx + m3xx + m4xx)/(m2xx + m3xx + m4xx + m5xx)' }],
+                  [
+                    'AWS/ES',
+                    '2xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '2xx', period: 3600, stat: 'Sum', visible: false, id: 'm2xx' },
+                  ],
+                  [
+                    'AWS/ES',
+                    '3xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '3xx', period: 3600, stat: 'Sum', visible: false, id: 'm3xx' },
+                  ],
+                  [
+                    'AWS/ES',
+                    '4xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '4xx', period: 3600, stat: 'Sum', visible: false, id: 'm4xx' },
+                  ],
+                  [
+                    'AWS/ES',
+                    '5xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '5xx', period: 3600, stat: 'Sum', visible: false, id: 'm5xx' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My ES Domain - 6 hours',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(m2xx + m3xx + m4xx)/(m2xx + m3xx + m4xx + m5xx)' }],
+                  [
+                    'AWS/ES',
+                    '2xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '2xx', period: 21600, stat: 'Sum', visible: false, id: 'm2xx' },
+                  ],
+                  [
+                    'AWS/ES',
+                    '3xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '3xx', period: 21600, stat: 'Sum', visible: false, id: 'm3xx' },
+                  ],
+                  [
+                    'AWS/ES',
+                    '4xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '4xx', period: 21600, stat: 'Sum', visible: false, id: 'm4xx' },
+                  ],
+                  [
+                    'AWS/ES',
+                    '5xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '5xx', period: 21600, stat: 'Sum', visible: false, id: 'm5xx' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My ES Domain - 1 day',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(m2xx + m3xx + m4xx)/(m2xx + m3xx + m4xx + m5xx)' }],
+                  [
+                    'AWS/ES',
+                    '2xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '2xx', period: 86400, stat: 'Sum', visible: false, id: 'm2xx' },
+                  ],
+                  [
+                    'AWS/ES',
+                    '3xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '3xx', period: 86400, stat: 'Sum', visible: false, id: 'm3xx' },
+                  ],
+                  [
+                    'AWS/ES',
+                    '4xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '4xx', period: 86400, stat: 'Sum', visible: false, id: 'm4xx' },
+                  ],
+                  [
+                    'AWS/ES',
+                    '5xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '5xx', period: 86400, stat: 'Sum', visible: false, id: 'm5xx' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My ES Domain - 30 days',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(m2xx + m3xx + m4xx)/(m2xx + m3xx + m4xx + m5xx)' }],
+                  [
+                    'AWS/ES',
+                    '2xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '2xx', period: 2592000, stat: 'Sum', visible: false, id: 'm2xx' },
+                  ],
+                  [
+                    'AWS/ES',
+                    '3xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '3xx', period: 2592000, stat: 'Sum', visible: false, id: 'm3xx' },
+                  ],
+                  [
+                    'AWS/ES',
+                    '4xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '4xx', period: 2592000, stat: 'Sum', visible: false, id: 'm4xx' },
+                  ],
+                  [
+                    'AWS/ES',
+                    '5xx',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: '5xx', period: 2592000, stat: 'Sum', visible: false, id: 'm5xx' },
+                  ],
+                ]),
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
   });
-});
 
-describe('ElasticSearchLatency', () => {
-  const slos = [
-    {
-      type: 'ElasticSearchLatency',
-      domainName: 'domainName',
-      accountId: 'accountId',
-      title: 'My ES Domain',
-      sloThreshold: 0.99,
-      latencyThreshold: 2000,
-    },
-  ];
+  describe('ElasticSearchLatency', () => {
+    const slos = [
+      {
+        type: 'ElasticSearchLatency',
+        domainName: 'domainName',
+        accountId: 'accountId',
+        title: 'My ES Domain',
+        sloThreshold: 0.99,
+        latencyThreshold: 2000,
+      },
+    ];
 
-  it('constructs a dashboard with all four windows: 2%, 5%, 10%, and 100%', () => {
-    const stack = new Stack();
-    new SLOAlarmsDashboard(stack, 'TestAlarmsDashboard', { slos, dashboardName: 'TestAlarmsDashboard' });
+    it('constructs a dashboard with all four windows: 2%, 5%, 10%, and 100%', () => {
+      const stack = new Stack();
+      new SLOAlarmsDashboard(stack, 'TestAlarmsDashboard', { slos, dashboardName: 'TestAlarmsDashboard' });
+      const dashBody = Capture.anyType();
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Dashboard', {
+          DashboardBody: dashBody.capture(),
+          DashboardName: 'TestAlarmsDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My ES Domain - 60 minutes`,
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/ES',
+                    'SearchLatency',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: 'Latency p85.60', period: 3600, stat: 'p85.60' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My ES Domain - 6 hours',
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/ES',
+                    'SearchLatency',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: 'Latency p94.00', period: 21600, stat: 'p94.00' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My ES Domain - 1 day',
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/ES',
+                    'SearchLatency',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: 'Latency p99.00', period: 86400, stat: 'p99.00' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My ES Domain - 30 days',
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/ES',
+                    'SearchLatency',
+                    'ClientId',
+                    'accountId',
+                    'DomainName',
+                    'domainName',
+                    { label: 'Latency p99.00', period: 2592000, stat: 'p99.00' },
+                  ],
+                ]),
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+  });
 
-    cdkExpect(stack).to(
-      haveResourceLike('AWS::CloudWatch::Dashboard', {
-        DashboardBody: {
-          'Fn::Join': [
-            '',
-            [
-              '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My ES Domain - 60 minutes","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[["AWS/ES","SearchLatency","ClientId","accountId","DomainName","domainName",{"label":"Latency p85.60","period":3600,"stat":"p85.60"}]],"annotations":{"horizontal":[{"label":"SLO","value":2000,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":2800}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My ES Domain - 6 hours","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[["AWS/ES","SearchLatency","ClientId","accountId","DomainName","domainName",{"label":"Latency p94.00","period":21600,"stat":"p94.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":2000,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":2800}}}},{"type":"metric","width":6,"height":6,"x":12,"y":0,"properties":{"view":"timeSeries","title":"My ES Domain - 1 day","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[["AWS/ES","SearchLatency","ClientId","accountId","DomainName","domainName",{"label":"Latency p99.00","period":86400,"stat":"p99.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":2000,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":2800}}}},{"type":"metric","width":6,"height":6,"x":18,"y":0,"properties":{"view":"timeSeries","title":"My ES Domain - 30 days","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[["AWS/ES","SearchLatency","ClientId","accountId","DomainName","domainName",{"label":"Latency p99.00","period":2592000,"stat":"p99.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":2000,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":2800}}}}]}',
-            ],
-          ],
-        },
-        DashboardName: 'TestAlarmsDashboard',
-      }),
-    );
+  describe('CustomAvailability', () => {
+    const slos = [
+      {
+        type: 'CustomAvailability',
+        namespace: 'CustomNamespace',
+        errorsMetricName: 'CustomErrorCountMetric',
+        countsMetricName: 'CustomRequestCountMetric',
+        title: 'My Custom Availability',
+        sloThreshold: 0.99,
+      },
+    ];
+
+    it('constructs a dashboard with all four windows: 2%, 5%, 10%, and 100%', () => {
+      const stack = new Stack();
+      new SLOAlarmsDashboard(stack, 'TestAlarmsDashboard', { slos, dashboardName: 'TestAlarmsDashboard' });
+      const dashBody = Capture.anyType();
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Dashboard', {
+          DashboardBody: dashBody.capture(),
+          DashboardName: 'TestAlarmsDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My Custom Availability - 60 minutes`,
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(requests - errors)/requests' }],
+                  [
+                    'CustomNamespace',
+                    'CustomRequestCountMetric',
+                    { label: 'Requests', period: 3600, stat: 'Sum', visible: false, id: 'requests' },
+                  ],
+                  [
+                    'CustomNamespace',
+                    'CustomErrorCountMetric',
+                    { label: 'Errors', period: 3600, stat: 'Sum', visible: false, id: 'errors' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My Custom Availability - 6 hours',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(requests - errors)/requests' }],
+                  [
+                    'CustomNamespace',
+                    'CustomRequestCountMetric',
+                    { label: 'Requests', period: 21600, stat: 'Sum', visible: false, id: 'requests' },
+                  ],
+                  [
+                    'CustomNamespace',
+                    'CustomErrorCountMetric',
+                    { label: 'Errors', period: 21600, stat: 'Sum', visible: false, id: 'errors' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My Custom Availability - 1 day',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(requests - errors)/requests' }],
+                  [
+                    'CustomNamespace',
+                    'CustomRequestCountMetric',
+                    { label: 'Requests', period: 86400, stat: 'Sum', visible: false, id: 'requests' },
+                  ],
+                  [
+                    'CustomNamespace',
+                    'CustomErrorCountMetric',
+                    { label: 'Errors', period: 86400, stat: 'Sum', visible: false, id: 'errors' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My Custom Availability - 30 days',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(requests - errors)/requests' }],
+                  [
+                    'CustomNamespace',
+                    'CustomRequestCountMetric',
+                    { label: 'Requests', period: 2592000, stat: 'Sum', visible: false, id: 'requests' },
+                  ],
+                  [
+                    'CustomNamespace',
+                    'CustomErrorCountMetric',
+                    { label: 'Errors', period: 2592000, stat: 'Sum', visible: false, id: 'errors' },
+                  ],
+                ]),
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+  });
+
+  describe('CustomLatency', () => {
+    const slos = [
+      {
+        type: 'CustomLatency',
+        namespace: 'CustomNamespace',
+        latencyMetricName: 'CustomLatencyMetric',
+        title: 'My Custom Latency',
+        sloThreshold: 0.99,
+        latencyThreshold: 2000,
+      },
+    ];
+
+    it('constructs a dashboard with all four windows: 2%, 5%, 10%, and 100%', () => {
+      const stack = new Stack();
+      new SLOAlarmsDashboard(stack, 'TestAlarmsDashboard', { slos, dashboardName: 'TestAlarmsDashboard' });
+      const dashBody = Capture.anyType();
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Dashboard', {
+          DashboardBody: dashBody.capture(),
+          DashboardName: 'TestAlarmsDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My Custom Latency - 60 minutes`,
+                metrics: expect.arrayContaining([
+                  ['CustomNamespace', 'CustomLatencyMetric', { label: 'Latency p85.60', period: 3600, stat: 'p85.60' }],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My Custom Latency - 6 hours',
+                metrics: expect.arrayContaining([
+                  [
+                    'CustomNamespace',
+                    'CustomLatencyMetric',
+                    { label: 'Latency p94.00', period: 21600, stat: 'p94.00' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My Custom Latency - 1 day',
+                metrics: expect.arrayContaining([
+                  [
+                    'CustomNamespace',
+                    'CustomLatencyMetric',
+                    { label: 'Latency p99.00', period: 86400, stat: 'p99.00' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My Custom Latency - 30 days',
+                metrics: expect.arrayContaining([
+                  [
+                    'CustomNamespace',
+                    'CustomLatencyMetric',
+                    { label: 'Latency p99.00', period: 2592000, stat: 'p99.00' },
+                  ],
+                ]),
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
   });
 });

--- a/tests/slos/alarms.test.ts
+++ b/tests/slos/alarms.test.ts
@@ -29,6 +29,22 @@ describe('SLOAlarms', () => {
       sloThreshold: 0.99,
       latencyThreshold: 2000,
     },
+    {
+      type: 'CustomAvailability',
+      namespace: 'CustomNamespace',
+      errorsMetricName: 'CustomErrorCountMetric',
+      countsMetricName: 'CustomRequestCountMetric',
+      title: 'My Custom Availability',
+      sloThreshold: 0.99,
+    },
+    {
+      type: 'CustomLatency',
+      namespace: 'CustomNamespace',
+      latencyMetricName: 'CustomLatencyMetric',
+      title: 'My Custom Latency',
+      sloThreshold: 0.99,
+      latencyThreshold: 2000,
+    },
   ];
   const invalidSlos = [{ type: 'SomeUndefined', apiName: 'apiName', title: 'My Made Up SLO', sloThreshold: 0.999 }];
 

--- a/tests/slos/custom-availability-metric.test.ts
+++ b/tests/slos/custom-availability-metric.test.ts
@@ -1,0 +1,62 @@
+import { CustomAvailabilityMetric } from '../../src/slos/custom-availability-metric';
+import { Windows } from '../../src/slos/windows';
+import { Duration } from '@aws-cdk/core';
+import { Metric } from '@aws-cdk/aws-cloudwatch';
+
+describe('CustomAvailabilityMetric', () => {
+  const defaultProps = {
+    namespace: 'testNamespace',
+    errorsMetricName: 'testErrorsMetricName',
+    countsMetricName: 'testCountsMetricName',
+    sloWindow: Windows.twoPercentLong,
+  };
+
+  test('uses sum for the statistic in all metrics', () => {
+    const expression = new CustomAvailabilityMetric(defaultProps);
+    Object.keys(expression.usingMetrics).forEach(metric => {
+      const typedMetric = expression.usingMetrics[metric] as Metric;
+      expect(typedMetric.statistic).toEqual('Sum');
+    });
+  });
+
+  test('uses the given namespace for all metrics', () => {
+    const expression = new CustomAvailabilityMetric(defaultProps);
+    Object.keys(expression.usingMetrics).forEach(metric => {
+      const typedMetric = expression.usingMetrics[metric] as Metric;
+      expect(typedMetric.namespace).toEqual('testNamespace');
+    });
+  });
+
+  test('uses the given countsMetricName as request count', () => {
+    const expression = new CustomAvailabilityMetric(defaultProps);
+    const typedMetric = expression.usingMetrics.requests as Metric;
+    expect(typedMetric.metricName).toEqual('testCountsMetricName');
+  });
+
+  test('uses the given errorsMetricName as error count', () => {
+    const expression = new CustomAvailabilityMetric(defaultProps);
+    const typedMetric = expression.usingMetrics.errors as Metric;
+    expect(typedMetric.metricName).toEqual('testErrorsMetricName');
+  });
+
+  test('uses fraction of successful requests as the expression', () => {
+    const expression = new CustomAvailabilityMetric(defaultProps);
+    expect(expression.expression).toEqual('(requests - errors)/requests');
+  });
+
+  test('uses no other dimensions in any metrics, since custom metrics cannot be pushed with dimensions', () => {
+    const expression = new CustomAvailabilityMetric(defaultProps);
+    Object.keys(expression.usingMetrics).forEach(metric => {
+      const typedMetric = expression.usingMetrics[metric] as Metric;
+      expect(typedMetric.dimensions).toEqual(undefined);
+    });
+  });
+
+  test('uses the alert window size for the period in all metrics', () => {
+    const expression = new CustomAvailabilityMetric(defaultProps);
+    Object.keys(expression.usingMetrics).forEach(metric => {
+      const typedMetric = expression.usingMetrics[metric] as Metric;
+      expect(typedMetric.period).toEqual(Duration.hours(1));
+    });
+  });
+});

--- a/tests/slos/custom-availability-widget.test.ts
+++ b/tests/slos/custom-availability-widget.test.ts
@@ -1,0 +1,37 @@
+import { CustomAvailabilityWidget } from '../../src/slos/custom-availability-widget';
+import { CustomAvailabilityMetric } from '../../src/slos/custom-availability-metric';
+import { AvailabilityWidget } from '../../src/slos/availability-widget';
+import { Windows } from '../../src/slos/windows';
+import { mocked } from 'ts-jest/dist/util/testing';
+
+const mockInstance = { foo: 'bar' };
+
+jest.mock('../../src/slos/custom-availability-metric', () => {
+  return {
+    CustomAvailabilityMetric: jest.fn().mockImplementation(() => {
+      return mockInstance;
+    }),
+  };
+});
+jest.mock('../../src/slos/availability-widget');
+
+describe('CustomAvailabilityWidget', () => {
+  const MockedCustomAvailabilityMetric = mocked(CustomAvailabilityMetric, true);
+  const MockedAvailabilityWidget = mocked(AvailabilityWidget, true);
+
+  beforeEach(() => {
+    MockedCustomAvailabilityMetric.mockClear();
+    MockedAvailabilityWidget.mockClear();
+  });
+
+  it('uses the CustomAvailabilityMetric class as its availability metric when constructing an AvailabilityWidget', () => {
+    new CustomAvailabilityWidget({
+      namespace: 'namespace',
+      errorsMetricName: 'errorsMetricName',
+      countsMetricName: 'countsMetricName',
+      sloThreshold: 0.99,
+      sloWindow: Windows.twoPercentLong,
+    });
+    expect(MockedAvailabilityWidget).toHaveBeenCalledWith(expect.objectContaining({ availability: mockInstance }));
+  });
+});

--- a/tests/slos/custom-latency-metric.test.ts
+++ b/tests/slos/custom-latency-metric.test.ts
@@ -1,0 +1,77 @@
+import { CustomLatencyMetric } from '../../src/slos/custom-latency-metric';
+import { Windows } from '../../src/slos/windows';
+import { Duration } from '@aws-cdk/core';
+
+describe('CustomAvailabilityMetric', () => {
+  const defaultProps = {
+    namespace: 'testNamespace',
+    latencyMetricName: 'testLatencyMetric',
+    sloThreshold: 0.99,
+    latencyThreshold: 200,
+    sloWindow: Windows.twoPercentLong,
+  };
+
+  test('uses the window burn rate threshold for the statistic and puts the statistic in its label', () => {
+    const expectations = [
+      {
+        sloThreshold: 0.999,
+        windows: [
+          { window: Windows.twoPercentLong, expectedStatistic: 'p98.56' },
+          { window: Windows.fivePercentLong, expectedStatistic: 'p99.40' },
+          { window: Windows.tenPercentLong, expectedStatistic: 'p99.90' },
+        ],
+      },
+      {
+        sloThreshold: 0.95,
+        windows: [
+          { window: Windows.twoPercentLong, expectedStatistic: 'p28.00' },
+          { window: Windows.fivePercentLong, expectedStatistic: 'p70.00' },
+          { window: Windows.tenPercentLong, expectedStatistic: 'p95.00' },
+        ],
+      },
+      {
+        sloThreshold: 0.5,
+        windows: [{ window: Windows.tenPercentLong, expectedStatistic: 'p50.00' }],
+      },
+    ];
+    expectations.forEach(expectation => {
+      expectation.windows.forEach(window => {
+        const metric = new CustomLatencyMetric({
+          namespace: 'testNamespace',
+          latencyMetricName: 'testLatencyMetric',
+          sloThreshold: expectation.sloThreshold,
+          sloWindow: window.window,
+        });
+        expect(metric.statistic).toEqual(window.expectedStatistic);
+        expect(metric.label).toEqual(`Latency ${window.expectedStatistic}`);
+      });
+    });
+  });
+
+  test('uses the given namespace', () => {
+    const metric = new CustomLatencyMetric(defaultProps);
+    expect(metric.namespace).toEqual('testNamespace');
+  });
+
+  test('uses given latency metric name', () => {
+    const metric = new CustomLatencyMetric(defaultProps);
+    expect(metric.metricName).toEqual('testLatencyMetric');
+  });
+
+  test('uses no other dimensions in any metrics, since custom metrics cannot be pushed with dimensions', () => {
+    const metric = new CustomLatencyMetric(defaultProps);
+    expect(metric.dimensions).toEqual(undefined);
+  });
+
+  test('uses the alert window size for the period', () => {
+    const metric = new CustomLatencyMetric(defaultProps);
+    expect(metric.period).toEqual(Duration.hours(1));
+  });
+
+  test('uses p0 for the statistic when too small a window is used for the threshold', () => {
+    const props = defaultProps;
+    props.sloThreshold = 0.5;
+    const metric = new CustomLatencyMetric(props);
+    expect(metric.statistic).toEqual('p0.00');
+  });
+});

--- a/tests/slos/custom-latency-widget.test.ts
+++ b/tests/slos/custom-latency-widget.test.ts
@@ -1,0 +1,37 @@
+import { CustomLatencyWidget } from '../../src/slos/custom-latency-widget';
+import { CustomLatencyMetric } from '../../src/slos/custom-latency-metric';
+import { LatencyWidget } from '../../src/slos/latency-widget';
+import { Windows } from '../../src/slos/windows';
+import { mocked } from 'ts-jest/dist/util/testing';
+
+const mockInstance = { foo: 'bar' };
+
+jest.mock('../../src/slos/custom-latency-metric', () => {
+  return {
+    CustomLatencyMetric: jest.fn().mockImplementation(() => {
+      return mockInstance;
+    }),
+  };
+});
+jest.mock('../../src/slos/latency-widget');
+
+describe('CustomLatencyWidget', () => {
+  const MockedCustomLatencyMetric = mocked(CustomLatencyMetric, true);
+  const MockedLatencyWidget = mocked(LatencyWidget, true);
+
+  beforeEach(() => {
+    MockedCustomLatencyMetric.mockClear();
+    MockedLatencyWidget.mockClear();
+  });
+
+  it('uses the CustomLatencyMetric class as its latency metric when constructing an LatencyWidget', () => {
+    new CustomLatencyWidget({
+      namespace: 'namespace',
+      latencyMetricName: 'latencyMetricName',
+      sloThreshold: 0.99,
+      latencyThreshold: 200,
+      sloWindow: Windows.twoPercentLong,
+    });
+    expect(MockedLatencyWidget).toHaveBeenCalledWith(expect.objectContaining({ latency: mockInstance }));
+  });
+});

--- a/tests/slos/helpers.ts
+++ b/tests/slos/helpers.ts
@@ -1,0 +1,18 @@
+/**
+ * DashboardBody is often a stringified json, but with an Fn::Join to concatenate the string with references
+ * such as { Ref: AWS::Region }. This makes it difficult to parse as a single json for matching. This function
+ * Collapses the Fn::Join into a single string. Replacing any { Ref: ResourceId } object params with the literal
+ * string ${ResourceId}.
+ *
+ * @param dashBody The captured DashboardBody that contains the Fn::Join
+ */
+export const collapseJoin = (dashBody: any): string => {
+  const joinParams = dashBody['Fn::Join'];
+  return Object.values(joinParams[1]).reduce((previous: string, current: any) => {
+    let val = current;
+    if (typeof val === 'object' && val['Ref'] !== undefined)
+      // Replace the object { Ref: ABC123 } with the literal string '${ABC123}'
+      val = `\${${val['Ref']}}`;
+    return previous + val;
+  }, '');
+};

--- a/tests/slos/performance-dashboard.test.ts
+++ b/tests/slos/performance-dashboard.test.ts
@@ -1,6 +1,7 @@
-import { expect as cdkExpect, haveResourceLike } from '@aws-cdk/assert';
+import { Capture, expect as cdkExpect, haveResourceLike } from '@aws-cdk/assert';
 import { SLOPerformanceDashboard } from '../../src/slos/performance-dashboard';
 import { Stack } from '@aws-cdk/core';
+import { collapseJoin } from './helpers';
 
 describe('SLOPerformanceDashboard', () => {
   it('throws an excpetion if theres an unknown type', () => {
@@ -60,57 +61,32 @@ describe('SLOPerformanceDashboard', () => {
       },
     ];
     const stack = new Stack();
-    new SLOPerformanceDashboard(stack, 'TestAlarms', { slos });
+    new SLOPerformanceDashboard(stack, 'TestPerformanceDashboard', { slos, dashboardName: 'TestPerformanceDashboard' });
+    const dashBody = Capture.anyType();
     cdkExpect(stack).to(
       haveResourceLike('AWS::CloudWatch::Dashboard', {
-        DashboardBody: {
-          'Fn::Join': [
-            '',
-            [
-              '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - Availability","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":2592000,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"SLO","value":0.999,"fill":"below","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0.995,"max":1}}}},{"type":"metric","width":6,"height":6,"x":6,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - Latency 200ms","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[["AWS/CloudFront","OriginLatency","DistributionId","myDistributionId","Region","Global",{"label":"Latency p95.00","period":2592000,"stat":"p95.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":200,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":280}}}},{"type":"metric","width":6,"height":6,"x":12,"y":0,"properties":{"view":"timeSeries","title":"My API - Availability","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[[{"label":"Availability","expression":"(gatewayRequests - gatewayErrors)/gatewayRequests"}],["AWS/ApiGateway","Count","ApiName","myApiName",{"label":"Requests","period":2592000,"stat":"Sum","visible":false,"id":"gatewayRequests"}],["AWS/ApiGateway","5XXError","ApiName","myApiName",{"label":"Error rate","period":2592000,"stat":"Sum","visible":false,"id":"gatewayErrors"}]],"annotations":{"horizontal":[{"label":"SLO","value":0.99,"fill":"below","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0.95,"max":1}}}},{"type":"metric","width":6,"height":6,"x":18,"y":0,"properties":{"view":"timeSeries","title":"My API - Latency 2000ms","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[["AWS/ApiGateway","Latency","ApiName","myApiName",{"label":"Latency p99.00","period":2592000,"stat":"p99.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":2000,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":2800}}}},{"type":"metric","width":6,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"My Cloudfront - Availability","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":2592000,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"SLO","value":0.999,"fill":"below","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0.995,"max":1}}}},{"type":"metric","width":6,"height":6,"x":6,"y":6,"properties":{"view":"timeSeries","title":"My Cloudfront - Latency 200ms","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[["AWS/CloudFront","OriginLatency","DistributionId","myDistributionId","Region","Global",{"label":"Latency p95.00","period":2592000,"stat":"p95.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":200,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":280}}}},{"type":"metric","width":6,"height":6,"x":12,"y":6,"properties":{"view":"timeSeries","title":"My API - Availability","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[[{"label":"Availability","expression":"(gatewayRequests - gatewayErrors)/gatewayRequests"}],["AWS/ApiGateway","Count","ApiName","myApiName",{"label":"Requests","period":2592000,"stat":"Sum","visible":false,"id":"gatewayRequests"}],["AWS/ApiGateway","5XXError","ApiName","myApiName",{"label":"Error rate","period":2592000,"stat":"Sum","visible":false,"id":"gatewayErrors"}]],"annotations":{"horizontal":[{"label":"SLO","value":0.99,"fill":"below","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0.95,"max":1}}}},{"type":"metric","width":6,"height":6,"x":18,"y":6,"properties":{"view":"timeSeries","title":"My API - Latency 2000ms","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[["AWS/ApiGateway","Latency","ApiName","myApiName",{"label":"Latency p99.00","period":2592000,"stat":"p99.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":2000,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":2800}}}},{"type":"metric","width":6,"height":6,"x":0,"y":12,"properties":{"view":"timeSeries","title":"My ES Domain - Availability","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[[{"label":"Availability","expression":"(m2xx + m3xx + m4xx)/(m2xx + m3xx + m4xx + m5xx)"}],["AWS/ES","2xx","ClientId","accountId","DomainName","domainName",{"label":"2xx","period":2592000,"stat":"Sum","visible":false,"id":"m2xx"}],["AWS/ES","3xx","ClientId","accountId","DomainName","domainName",{"label":"3xx","period":2592000,"stat":"Sum","visible":false,"id":"m3xx"}],["AWS/ES","4xx","ClientId","accountId","DomainName","domainName",{"label":"4xx","period":2592000,"stat":"Sum","visible":false,"id":"m4xx"}],["AWS/ES","5xx","ClientId","accountId","DomainName","domainName",{"label":"5xx","period":2592000,"stat":"Sum","visible":false,"id":"m5xx"}]],"annotations":{"horizontal":[{"label":"SLO","value":0.99,"fill":"below","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0.95,"max":1}}}},{"type":"metric","width":6,"height":6,"x":6,"y":12,"properties":{"view":"timeSeries","title":"My ES Domain - Latency 2000ms","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[["AWS/ES","SearchLatency","ClientId","accountId","DomainName","domainName",{"label":"Latency p99.00","period":2592000,"stat":"p99.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":2000,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":2800}}}}]}',
-            ],
-          ],
-        },
+        DashboardBody: dashBody.capture(),
+        DashboardName: 'TestPerformanceDashboard',
+      }),
+    );
+    const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+    const rowOneWidget = expect.objectContaining({ y: 0, height: 6 });
+    const rowTwoWidget = expect.objectContaining({ y: 6, height: 6 });
+    const rowThreeWidget = expect.objectContaining({ y: 12, height: 6 });
+    expect(dashObj).toEqual(
+      expect.objectContaining({
+        widgets: [
+          rowOneWidget,
+          rowOneWidget,
+          rowOneWidget,
+          rowOneWidget,
+          rowTwoWidget,
+          rowTwoWidget,
+          rowTwoWidget,
+          rowTwoWidget,
+          rowThreeWidget,
+          rowThreeWidget,
+        ],
       }),
     );
   });
@@ -130,22 +106,17 @@ describe('SLOPerformanceDashboard', () => {
       dashboardName: 'TestPerformanceDashboard',
       start: '-P1234D',
     });
-
+    const dashBody = Capture.anyType();
     cdkExpect(stack).to(
       haveResourceLike('AWS::CloudWatch::Dashboard', {
-        DashboardBody: {
-          'Fn::Join': [
-            '',
-            [
-              '{"start":"-P1234D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - Availability","region":"',
-              {
-                Ref: 'AWS::Region',
-              },
-              '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":2592000,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"SLO","value":0.999,"fill":"below","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0.995,"max":1}}}}]}',
-            ],
-          ],
-        },
+        DashboardBody: dashBody.capture(),
         DashboardName: 'TestPerformanceDashboard',
+      }),
+    );
+    const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+    expect(dashObj).toEqual(
+      expect.objectContaining({
+        start: '-P1234D',
       }),
     );
   });
@@ -167,21 +138,35 @@ describe('SLOPerformanceDashboard', () => {
         dashboardName: 'TestPerformanceDashboard',
       });
 
+      const dashBody = Capture.anyType();
       cdkExpect(stack).to(
         haveResourceLike('AWS::CloudWatch::Dashboard', {
-          DashboardBody: {
-            'Fn::Join': [
-              '',
-              [
-                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - Availability","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[[{"label":"Availability","expression":"1-(errorRate/100)"}],["AWS/CloudFront","5xxErrorRate","DistributionId","myDistributionId","Region","Global",{"label":"Error rate","period":2592000,"visible":false,"id":"errorRate"}]],"annotations":{"horizontal":[{"label":"SLO","value":0.999,"fill":"below","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0.995,"max":1}}}}]}',
-              ],
-            ],
-          },
+          DashboardBody: dashBody.capture(),
           DashboardName: 'TestPerformanceDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My Cloudfront - Availability`,
+                metrics: [
+                  [{ label: 'Availability', expression: '1-(errorRate/100)' }],
+                  [
+                    'AWS/CloudFront',
+                    '5xxErrorRate',
+                    'DistributionId',
+                    'myDistributionId',
+                    'Region',
+                    'Global',
+                    { label: 'Error rate', period: 2592000, visible: false, id: 'errorRate' },
+                  ],
+                ],
+              }),
+            }),
+          ]),
         }),
       );
     });
@@ -205,21 +190,34 @@ describe('SLOPerformanceDashboard', () => {
         dashboardName: 'TestPerformanceDashboard',
       });
 
+      const dashBody = Capture.anyType();
       cdkExpect(stack).to(
         haveResourceLike('AWS::CloudWatch::Dashboard', {
-          DashboardBody: {
-            'Fn::Join': [
-              '',
-              [
-                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My Cloudfront - Latency 200ms","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[["AWS/CloudFront","OriginLatency","DistributionId","myDistributionId","Region","Global",{"label":"Latency p95.00","period":2592000,"stat":"p95.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":200,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":280}}}}]}',
-              ],
-            ],
-          },
+          DashboardBody: dashBody.capture(),
           DashboardName: 'TestPerformanceDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My Cloudfront - Latency 200ms`,
+                metrics: [
+                  [
+                    'AWS/CloudFront',
+                    'OriginLatency',
+                    'DistributionId',
+                    'myDistributionId',
+                    'Region',
+                    'Global',
+                    { label: 'Latency p95.00', period: 2592000, stat: 'p95.00' },
+                  ],
+                ],
+              }),
+            }),
+          ]),
         }),
       );
     });
@@ -235,21 +233,40 @@ describe('SLOPerformanceDashboard', () => {
         dashboardName: 'TestPerformanceDashboard',
       });
 
+      const dashBody = Capture.anyType();
       cdkExpect(stack).to(
         haveResourceLike('AWS::CloudWatch::Dashboard', {
-          DashboardBody: {
-            'Fn::Join': [
-              '',
-              [
-                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My API - Availability","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[[{"label":"Availability","expression":"(gatewayRequests - gatewayErrors)/gatewayRequests"}],["AWS/ApiGateway","Count","ApiName","myApiName",{"label":"Requests","period":2592000,"stat":"Sum","visible":false,"id":"gatewayRequests"}],["AWS/ApiGateway","5XXError","ApiName","myApiName",{"label":"Error rate","period":2592000,"stat":"Sum","visible":false,"id":"gatewayErrors"}]],"annotations":{"horizontal":[{"label":"SLO","value":0.99,"fill":"below","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0.95,"max":1}}}}]}',
-              ],
-            ],
-          },
+          DashboardBody: dashBody.capture(),
           DashboardName: 'TestPerformanceDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My API - Availability`,
+                metrics: [
+                  [{ label: 'Availability', expression: '(gatewayRequests - gatewayErrors)/gatewayRequests' }],
+                  [
+                    'AWS/ApiGateway',
+                    'Count',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Requests', period: 2592000, stat: 'Sum', visible: false, id: 'gatewayRequests' },
+                  ],
+                  [
+                    'AWS/ApiGateway',
+                    '5XXError',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Error rate', period: 2592000, stat: 'Sum', visible: false, id: 'gatewayErrors' },
+                  ],
+                ],
+              }),
+            }),
+          ]),
         }),
       );
     });
@@ -267,21 +284,134 @@ describe('SLOPerformanceDashboard', () => {
         dashboardName: 'TestPerformanceDashboard',
       });
 
+      const dashBody = Capture.anyType();
       cdkExpect(stack).to(
         haveResourceLike('AWS::CloudWatch::Dashboard', {
-          DashboardBody: {
-            'Fn::Join': [
-              '',
-              [
-                '{"start":"-P360D","widgets":[{"type":"metric","width":6,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"My API - Latency 2000ms","region":"',
-                {
-                  Ref: 'AWS::Region',
-                },
-                '","metrics":[["AWS/ApiGateway","Latency","ApiName","myApiName",{"label":"Latency p99.00","period":2592000,"stat":"p99.00"}]],"annotations":{"horizontal":[{"label":"SLO","value":2000,"fill":"above","color":"#d62728","yAxis":"left"}]},"yAxis":{"left":{"min":0,"max":2800}}}}]}',
-              ],
-            ],
-          },
+          DashboardBody: dashBody.capture(),
           DashboardName: 'TestPerformanceDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My API - Latency 2000ms`,
+                metrics: [
+                  [
+                    'AWS/ApiGateway',
+                    'Latency',
+                    'ApiName',
+                    'myApiName',
+                    { label: 'Latency p99.00', period: 2592000, stat: 'p99.00' },
+                  ],
+                ],
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+  });
+
+  describe('CustomAvailability', () => {
+    const slos = [
+      {
+        type: 'CustomAvailability',
+        namespace: 'CustomNamespace',
+        errorsMetricName: 'CustomErrorCountMetric',
+        countsMetricName: 'CustomRequestCountMetric',
+        title: 'My Custom Availability',
+        sloThreshold: 0.99,
+      },
+    ];
+
+    it('constructs a dashboard with a 30 day window widget', () => {
+      const stack = new Stack();
+      new SLOPerformanceDashboard(stack, 'TestPerformanceDashboard', {
+        slos,
+        dashboardName: 'TestPerformanceDashboard',
+      });
+
+      const dashBody = Capture.anyType();
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Dashboard', {
+          DashboardBody: dashBody.capture(),
+          DashboardName: 'TestPerformanceDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My Custom Availability - Availability`,
+                metrics: [
+                  [{ label: 'Availability', expression: '(requests - errors)/requests' }],
+                  [
+                    'CustomNamespace',
+                    'CustomRequestCountMetric',
+                    { label: 'Requests', period: 2592000, stat: 'Sum', visible: false, id: 'requests' },
+                  ],
+                  [
+                    'CustomNamespace',
+                    'CustomErrorCountMetric',
+                    { label: 'Errors', period: 2592000, stat: 'Sum', visible: false, id: 'errors' },
+                  ],
+                ],
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+  });
+
+  describe('CustomLatency', () => {
+    const slos = [
+      {
+        type: 'CustomLatency',
+        namespace: 'CustomNamespace',
+        latencyMetricName: 'CustomLatencyMetric',
+        title: 'My Custom Latency',
+        sloThreshold: 0.99,
+        latencyThreshold: 2000,
+      },
+    ];
+
+    it('constructs a dashboard with a 30 day window widget', () => {
+      const stack = new Stack();
+      new SLOPerformanceDashboard(stack, 'TestPerformanceDashboard', {
+        slos,
+        dashboardName: 'TestPerformanceDashboard',
+      });
+
+      const dashBody = Capture.anyType();
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Dashboard', {
+          DashboardBody: dashBody.capture(),
+          DashboardName: 'TestPerformanceDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: [
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My Custom Latency - Latency 2000ms`,
+                metrics: expect.arrayContaining([
+                  [
+                    'CustomNamespace',
+                    'CustomLatencyMetric',
+                    { label: 'Latency p99.00', period: 2592000, stat: 'p99.00' },
+                  ],
+                ]),
+              }),
+            }),
+          ],
         }),
       );
     });


### PR DESCRIPTION
This adds the ability to create SLO Alarms and Dashboards that are based
on custom metrics. When building SLOs for other types, we can enforce
using AWS provided namespaces and metrics for the SLIs. When a custom
metric is used, such as in the case of extracting metrics from nginx
logs, the namespaces and metric names must be given to us as part of the
SLO, ex:

```typescript
const slos = [
  {
    type: 'CustomAvailability',
    namespace: 'CustomNamespace',
    errorsMetricName: 'CustomErrorCountMetric',
    countsMetricName: 'CustomRequestCountMetric',
    title: 'My Custom Availability',
    sloThreshold: 0.99,
  },
  {
    type: 'CustomLatency',
    namespace: 'CustomNamespace',
    latencyMetricName: 'CustomLatencyMetric',
    title: 'My Custom Latency',
    sloThreshold: 0.99,
    latencyThreshold: 2000,
  },
];
```

Additionally, this adds better parsing of dashboard bodies in tests.
Testing dashboards in cdk can be a bit of a pain because it's a mix of
a Fn::Import and stringified json. Added a helper function that collapses
this all into a single stringifed json to allow us to more easily do
partial matching on dashboard bodies. Rewrote the alarms-dashboard and
performance-dashboard tests to use this new method with more precise
matching.