### PR TITLE
feat(slo): add appsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ const slos = [
     latencyThreshold: 2000,
   },
   {
+    type: 'AppSyncAvailability',
+    apiId: 'myAppSyncAPI-prod',
+    title: 'AppSync API',
+    sloThreshold: 0.99,
+  },
+  {
+    type: 'AppSyncLatency',
+    apiId: 'myAppSyncAPI-prod',
+    title: 'AppSync API',
+    sloThreshold: 0.95,
+    latencyThreshold: 2000,
+  },
+  {
     type: 'ElasticSearchAvailability',
     domainName: 'myes-prod',
     accountId: '1234567890',

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "preversion": "npm test && npm run lint",
     "version": "npm run generate-changelog && npm run format && git add CHANGELOG.md && git checkout -B bump-$npm_package_version && git add -A src",
     "postversion": "git push --set-upstream origin bump-$npm_package_version && git push --tags",
-    "watch": "tsc-watch --onSuccess \"npm run test\""
+    "watch": "tsc-watch"
   },
   "repository": {
     "type": "git",

--- a/src/slos/alarms-dashboard.ts
+++ b/src/slos/alarms-dashboard.ts
@@ -2,6 +2,8 @@ import { Dashboard, DashboardProps } from '@aws-cdk/aws-cloudwatch';
 import * as cdk from '@aws-cdk/core';
 import { ApiAvailabilityWidget } from './api-availability-widget';
 import { ApiLatencyWidget } from './api-latency-widget';
+import { AppSyncAvailabilityWidget } from './appsync-availability-widget';
+import { AppSyncLatencyWidget } from './appsync-latency-widget';
 import { CloudfrontAvailabilityWidget } from './cloudfront-availability-widget';
 import { CloudfrontLatencyWidget } from './cloudfront-latency-widget';
 import { CustomAvailabilityWidget } from './custom-availability-widget';
@@ -12,6 +14,8 @@ import {
   AnySLO,
   ApiAvailabilitySLO,
   ApiLatencySLO,
+  AppSyncAvailabilitySLO,
+  AppSyncLatencySLO,
   CloudfrontAvailabilitySLO,
   CloudfrontLatencySLO,
   CustomAvailabilitySLO,
@@ -53,6 +57,32 @@ export class SLOAlarmsDashboard extends Dashboard {
     return windows.map(
       sloWindow =>
         new ApiLatencyWidget({
+          ...slo,
+          sloWindow,
+          showBurnRateThreshold: true,
+          addPeriodToTitle: true,
+        }),
+    );
+  };
+
+  // Creates an array of AppSyncAvailabilityWidgets for each window we are using
+  public static appSyncAvailabilityAlarmsRow = (windows: IAlertConfig[], slo: AppSyncAvailabilitySLO) => {
+    return windows.map(
+      sloWindow =>
+        new AppSyncAvailabilityWidget({
+          ...slo,
+          sloWindow,
+          showBurnRateThreshold: true,
+          addPeriodToTitle: true,
+        }),
+    );
+  };
+
+  // Creates an array of AppSyncLatencyWidgets for each window we are using
+  public static appSyncLatencyAlarmsRow = (windows: IAlertConfig[], slo: AppSyncLatencySLO) => {
+    return windows.map(
+      sloWindow =>
+        new AppSyncLatencyWidget({
           ...slo,
           sloWindow,
           showBurnRateThreshold: true,
@@ -149,6 +179,12 @@ export class SLOAlarmsDashboard extends Dashboard {
           break;
         case 'ApiLatency':
           result.push(SLOAlarmsDashboard.apiLatencyAlarmsRow(windows, slo as ApiLatencySLO));
+          break;
+        case 'AppSyncAvailability':
+          result.push(SLOAlarmsDashboard.appSyncAvailabilityAlarmsRow(windows, slo as AppSyncAvailabilitySLO));
+          break;
+        case 'AppSyncLatency':
+          result.push(SLOAlarmsDashboard.appSyncLatencyAlarmsRow(windows, slo as AppSyncLatencySLO));
           break;
         case 'CloudfrontAvailability':
           result.push(SLOAlarmsDashboard.cloudfrontAvailabilityAlarmsRow(windows, slo as CloudfrontAvailabilitySLO));

--- a/src/slos/appsync-availability-metric.ts
+++ b/src/slos/appsync-availability-metric.ts
@@ -1,0 +1,53 @@
+import { MathExpression, Metric } from '@aws-cdk/aws-cloudwatch';
+import { IAlertConfig } from './types';
+
+export interface IAppSyncAvailabilityMetricProps {
+  /**
+   * Id of the GraphQL API for this metric
+   */
+  readonly apiId: string;
+
+  /**
+   * The SLO window that this metric will be used for.
+   */
+  readonly sloWindow: IAlertConfig;
+}
+
+export class AppSyncAvailabilityMetric extends MathExpression {
+  /**
+   * Creates a metric that can be used as an SLI for AppSync API
+   * Availability SLOs
+   */
+  constructor(props: IAppSyncAvailabilityMetricProps) {
+    const errors = new Metric({
+      namespace: 'AWS/AppSync',
+      metricName: '5XXError',
+      dimensions: {
+        GraphQLAPIId: props.apiId,
+      },
+      statistic: 'Sum',
+      label: 'Error rate',
+    });
+
+    // There is no direct request count metric. Have to get this from the sample
+    // count for one of the error metrics.
+    // https://docs.aws.amazon.com/appsync/latest/devguide/monitoring.html#cw-metrics
+    const requests = new Metric({
+      namespace: 'AWS/AppSync',
+      metricName: '5XXError',
+      dimensions: {
+        GraphQLAPIId: props.apiId,
+      },
+      statistic: 'SampleCount',
+      label: 'Requests',
+    });
+
+    const myProps = {
+      label: 'Availability',
+      expression: '(requests - errors)/requests',
+      usingMetrics: { requests, errors },
+      period: props.sloWindow.alertWindow,
+    };
+    super({ ...props, ...myProps });
+  }
+}

--- a/src/slos/appsync-availability-widget.ts
+++ b/src/slos/appsync-availability-widget.ts
@@ -1,0 +1,20 @@
+import { AppSyncAvailabilityMetric } from './appsync-availability-metric';
+import { AvailabilityWidget } from './availability-widget';
+import { ISLOWidgetProps } from './types';
+
+export interface IAppSyncAvailabilityWidgetProps extends ISLOWidgetProps {
+  /**
+   * Id of the API for this metric
+   */
+  readonly apiId: string;
+}
+
+export class AppSyncAvailabilityWidget extends AvailabilityWidget {
+  /**
+   * Creates an availability widget using an AppSync API availability metric
+   */
+  constructor(props: IAppSyncAvailabilityWidgetProps) {
+    const availability = new AppSyncAvailabilityMetric({ apiId: props.apiId, sloWindow: props.sloWindow });
+    super({ availability, ...props });
+  }
+}

--- a/src/slos/appsync-latency-metric.ts
+++ b/src/slos/appsync-latency-metric.ts
@@ -1,0 +1,43 @@
+import { Metric } from '@aws-cdk/aws-cloudwatch';
+import { IAlertConfig } from './types';
+
+export interface IAppSyncLatencyMetricProps {
+  /**
+   * Id of the GraphQL API for this metric
+   */
+  readonly apiId: string;
+
+  /**
+   * The SLO window that this metric will be used for.
+   */
+  readonly sloWindow: IAlertConfig;
+
+  /**
+   * The decimal value for the threshold of the SLO.
+   */
+  readonly sloThreshold: number;
+}
+
+export class AppSyncLatencyMetric extends Metric {
+  /**
+   * Creates a metric that can be used as an SLI for AppSync API
+   * Latency SLOs
+   */
+  constructor(props: IAppSyncLatencyMetricProps) {
+    const sloBudget = 100 - props.sloThreshold * 100;
+    let alarmThreshold = 100 - props.sloWindow.burnRateThreshold * sloBudget;
+    alarmThreshold = Math.max(0, Math.min(alarmThreshold, 100));
+    const statistic = `p${alarmThreshold.toFixed(2)}`;
+    const myProps = {
+      namespace: 'AWS/AppSync',
+      metricName: 'Latency',
+      dimensions: {
+        GraphQLAPIId: props.apiId,
+      },
+      statistic,
+      label: `Latency ${statistic}`,
+      period: props.sloWindow.alertWindow,
+    };
+    super({ ...props, ...myProps });
+  }
+}

--- a/src/slos/appsync-latency-widget.ts
+++ b/src/slos/appsync-latency-widget.ts
@@ -1,0 +1,29 @@
+import { AppSyncLatencyMetric } from './appsync-latency-metric';
+import { LatencyWidget } from './latency-widget';
+import { ISLOWidgetProps } from './types';
+
+export interface IAppSyncLatencyWidgetProps extends ISLOWidgetProps {
+  /**
+   * Id of the API for this metric
+   */
+  readonly apiId: string;
+
+  /**
+   * The integer value for the latency threshold in ms.
+   */
+  readonly latencyThreshold: number;
+}
+
+export class AppSyncLatencyWidget extends LatencyWidget {
+  /**
+   * Creates a latency widget using an AppSync API latency metric
+   */
+  constructor(props: IAppSyncLatencyWidgetProps) {
+    const latency = new AppSyncLatencyMetric({
+      apiId: props.apiId,
+      sloThreshold: props.sloThreshold,
+      sloWindow: props.sloWindow,
+    });
+    super({ latency, ...props });
+  }
+}

--- a/src/slos/performance-dashboard.ts
+++ b/src/slos/performance-dashboard.ts
@@ -2,6 +2,8 @@ import { Dashboard, DashboardProps } from '@aws-cdk/aws-cloudwatch';
 import * as cdk from '@aws-cdk/core';
 import { ApiAvailabilityWidget } from './api-availability-widget';
 import { ApiLatencyWidget } from './api-latency-widget';
+import { AppSyncAvailabilityWidget } from './appsync-availability-widget';
+import { AppSyncLatencyWidget } from './appsync-latency-widget';
 import { CloudfrontAvailabilityWidget } from './cloudfront-availability-widget';
 import { CloudfrontLatencyWidget } from './cloudfront-latency-widget';
 import { CustomAvailabilityWidget } from './custom-availability-widget';
@@ -12,6 +14,8 @@ import {
   AnySLO,
   ApiAvailabilitySLO,
   ApiLatencySLO,
+  AppSyncAvailabilitySLO,
+  AppSyncLatencySLO,
   CloudfrontAvailabilitySLO,
   CloudfrontLatencySLO,
   CustomAvailabilitySLO,
@@ -61,6 +65,26 @@ export class SLOPerformanceDashboard extends Dashboard {
                 ...apiLatencySlo,
                 sloWindow: Windows.thirtyDays,
                 title: `${apiLatencySlo.title} - Latency ${apiLatencySlo.latencyThreshold}ms`,
+              }),
+            );
+            break;
+          case 'AppSyncAvailability':
+            const appSyncAvailabilitySlo = slo as AppSyncAvailabilitySLO;
+            lastRow.push(
+              new AppSyncAvailabilityWidget({
+                ...appSyncAvailabilitySlo,
+                sloWindow: Windows.thirtyDays,
+                title: `${appSyncAvailabilitySlo.title} - Availability`,
+              }),
+            );
+            break;
+          case 'AppSyncLatency':
+            const appSyncLatencySlo = slo as AppSyncLatencySLO;
+            lastRow.push(
+              new AppSyncLatencyWidget({
+                ...appSyncLatencySlo,
+                sloWindow: Windows.thirtyDays,
+                title: `${appSyncLatencySlo.title} - Latency ${appSyncLatencySlo.latencyThreshold}ms`,
               }),
             );
             break;

--- a/src/slos/types.ts
+++ b/src/slos/types.ts
@@ -86,6 +86,13 @@ export interface ICustomLatencySLI {
   readonly latencyMetricName: string;
 }
 
+/**
+ * Properties specific to Appsync based Service Level Indicators
+ */
+export interface IAppSyncSLI {
+  readonly apiId: string;
+}
+
 // SLO types are combinations of the objective and the indicator
 export type ApiAvailabilitySLO = IAvailabilitySLO & IApiSLI;
 export type ApiLatencySLO = ILatencySLO & IApiSLI;
@@ -95,6 +102,8 @@ export type ElasticSearchAvailabilitySLO = IAvailabilitySLO & IElasticSearchSLI;
 export type ElasticSearchLatencySLO = ILatencySLO & IElasticSearchSLI;
 export type CustomAvailabilitySLO = IAvailabilitySLO & ICustomAvailibilitySLI;
 export type CustomLatencySLO = ILatencySLO & ICustomLatencySLI;
+export type AppSyncAvailabilitySLO = IAvailabilitySLO & IAppSyncSLI;
+export type AppSyncLatencySLO = ILatencySLO & IAppSyncSLI;
 export type AnySLO =
   | ApiAvailabilitySLO
   | ApiLatencySLO
@@ -103,7 +112,9 @@ export type AnySLO =
   | ElasticSearchAvailabilitySLO
   | ElasticSearchLatencySLO
   | CustomAvailabilitySLO
-  | CustomLatencySLO;
+  | CustomLatencySLO
+  | AppSyncAvailabilitySLO
+  | AppSyncLatencySLO;
 
 /**
  * Defines a configuration for alerting on burn rates within a window

--- a/tests/slos/alarms-dashboard.test.ts
+++ b/tests/slos/alarms-dashboard.test.ts
@@ -428,6 +428,198 @@ describe('SLOAlarmsDashboard', () => {
     });
   });
 
+  describe('AppSyncAvailability', () => {
+    const slos = [{ type: 'AppSyncAvailability', apiId: 'myApiId', title: 'My API', sloThreshold: 0.99 }];
+
+    it('constructs a dashboard with all four windows: 2%, 5%, 10%, and 100%', () => {
+      const stack = new Stack();
+      new SLOAlarmsDashboard(stack, 'TestAlarmsDashboard', { slos, dashboardName: 'TestAlarmsDashboard' });
+      const dashBody = Capture.anyType();
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Dashboard', {
+          DashboardBody: dashBody.capture(),
+          DashboardName: 'TestAlarmsDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My API - 60 minutes`,
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(requests - errors)/requests' }],
+                  [
+                    'AWS/AppSync',
+                    '5XXError',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Requests', period: 3600, stat: 'SampleCount', visible: false, id: 'requests' },
+                  ],
+                  [
+                    'AWS/AppSync',
+                    '5XXError',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Error rate', period: 3600, stat: 'Sum', visible: false, id: 'errors' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My API - 6 hours',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(requests - errors)/requests' }],
+                  [
+                    'AWS/AppSync',
+                    '5XXError',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Requests', period: 21600, stat: 'SampleCount', visible: false, id: 'requests' },
+                  ],
+                  [
+                    'AWS/AppSync',
+                    '5XXError',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Error rate', period: 21600, stat: 'Sum', visible: false, id: 'errors' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My API - 1 day',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(requests - errors)/requests' }],
+                  [
+                    'AWS/AppSync',
+                    '5XXError',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Requests', period: 86400, stat: 'SampleCount', visible: false, id: 'requests' },
+                  ],
+                  [
+                    'AWS/AppSync',
+                    '5XXError',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Error rate', period: 86400, stat: 'Sum', visible: false, id: 'errors' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My API - 30 days',
+                metrics: expect.arrayContaining([
+                  [{ label: 'Availability', expression: '(requests - errors)/requests' }],
+                  [
+                    'AWS/AppSync',
+                    '5XXError',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Requests', period: 2592000, stat: 'SampleCount', visible: false, id: 'requests' },
+                  ],
+                  [
+                    'AWS/AppSync',
+                    '5XXError',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Error rate', period: 2592000, stat: 'Sum', visible: false, id: 'errors' },
+                  ],
+                ]),
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+  });
+
+  describe('AppSyncLatency', () => {
+    const slos = [
+      { type: 'AppSyncLatency', apiId: 'myApiId', title: 'My API', sloThreshold: 0.99, latencyThreshold: 2000 },
+    ];
+
+    it('constructs a dashboard with all four windows: 2%, 5%, 10%, and 100%', () => {
+      const stack = new Stack();
+      new SLOAlarmsDashboard(stack, 'TestAlarmsDashboard', { slos, dashboardName: 'TestAlarmsDashboard' });
+      const dashBody = Capture.anyType();
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Dashboard', {
+          DashboardBody: dashBody.capture(),
+          DashboardName: 'TestAlarmsDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My API - 60 minutes`,
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/AppSync',
+                    'Latency',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Latency p85.60', period: 3600, stat: 'p85.60' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My API - 6 hours',
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/AppSync',
+                    'Latency',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Latency p94.00', period: 21600, stat: 'p94.00' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My API - 1 day',
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/AppSync',
+                    'Latency',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Latency p99.00', period: 86400, stat: 'p99.00' },
+                  ],
+                ]),
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: 'My API - 30 days',
+                metrics: expect.arrayContaining([
+                  [
+                    'AWS/AppSync',
+                    'Latency',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Latency p99.00', period: 2592000, stat: 'p99.00' },
+                  ],
+                ]),
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+  });
+
   describe('ElasticSearchAvailability', () => {
     const slos = [
       {

--- a/tests/slos/alarms.test.ts
+++ b/tests/slos/alarms.test.ts
@@ -14,6 +14,8 @@ describe('SLOAlarms', () => {
     },
     { type: 'ApiAvailability', apiName: 'myApiName', title: 'My API', sloThreshold: 0.99 },
     { type: 'ApiLatency', apiName: 'myApiName', title: 'My API', sloThreshold: 0.99, latencyThreshold: 2000 },
+    { type: 'AppSyncAvailability', apiId: 'myApiId', title: 'My AppSync API', sloThreshold: 0.99 },
+    { type: 'AppSyncLatency', apiId: 'myApiId', title: 'My AppSync API', sloThreshold: 0.99, latencyThreshold: 2000 },
     {
       type: 'ElasticSearchAvailability',
       domainName: 'domainName',
@@ -1501,6 +1503,708 @@ describe('SLOAlarms', () => {
       cdkExpect(stack).to(
         haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
           AlarmName: 'My API Latency P99 >= 2000ms (High Severity)',
+          AlarmDescription:
+            'Service is at risk of exceeding its error budget. Please use the links below to troubleshoot the problem:\n\nDashboard: dashboardLink\nRun book: runbookLink\nAlarms Dashboard: alarmsDashboardLink\n',
+        }),
+      );
+    });
+  });
+
+  describe('AppSyncAvailability', () => {
+    it('constructs an alarm for the 2.00% of 30 days budget burned in 5 minutes window', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Alarm', {
+          ComparisonOperator: 'LessThanOrEqualToThreshold',
+          EvaluationPeriods: 1,
+          AlarmName: 'My AppSync API Availability <= 0.99 - 2.00% of 30 days budget burned in 5 minutes',
+          DatapointsToAlarm: 1,
+          Metrics: [
+            {
+              Expression: '(requests - errors)/requests',
+              Id: 'expr_1',
+              Label: 'Availability',
+            },
+            {
+              Id: 'requests',
+              Label: 'Requests',
+              MetricStat: {
+                Metric: {
+                  Dimensions: [
+                    {
+                      Name: 'GraphQLAPIId',
+                      Value: 'myApiId',
+                    },
+                  ],
+                  MetricName: '5XXError',
+                  Namespace: 'AWS/AppSync',
+                },
+                Period: 300,
+                Stat: 'SampleCount',
+              },
+              ReturnData: false,
+            },
+            {
+              Id: 'errors',
+              Label: 'Error rate',
+              MetricStat: {
+                Metric: {
+                  Dimensions: [
+                    {
+                      Name: 'GraphQLAPIId',
+                      Value: 'myApiId',
+                    },
+                  ],
+                  MetricName: '5XXError',
+                  Namespace: 'AWS/AppSync',
+                },
+                Period: 300,
+                Stat: 'Sum',
+              },
+              ReturnData: false,
+            },
+          ],
+          Threshold: 0.8559999999999999,
+        }),
+      );
+    });
+
+    it('constructs an alarm for the 2.00% of 30 days budget burned in 60 minutes window', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Alarm', {
+          ComparisonOperator: 'LessThanOrEqualToThreshold',
+          EvaluationPeriods: 1,
+          AlarmName: 'My AppSync API Availability <= 0.99 - 2.00% of 30 days budget burned in 60 minutes',
+          DatapointsToAlarm: 1,
+          Metrics: [
+            {
+              Expression: '(requests - errors)/requests',
+              Id: 'expr_1',
+              Label: 'Availability',
+            },
+            {
+              Id: 'requests',
+              Label: 'Requests',
+              MetricStat: {
+                Metric: {
+                  Dimensions: [
+                    {
+                      Name: 'GraphQLAPIId',
+                      Value: 'myApiId',
+                    },
+                  ],
+                  MetricName: '5XXError',
+                  Namespace: 'AWS/AppSync',
+                },
+                Period: 3600,
+                Stat: 'SampleCount',
+              },
+              ReturnData: false,
+            },
+            {
+              Id: 'errors',
+              Label: 'Error rate',
+              MetricStat: {
+                Metric: {
+                  Dimensions: [
+                    {
+                      Name: 'GraphQLAPIId',
+                      Value: 'myApiId',
+                    },
+                  ],
+                  MetricName: '5XXError',
+                  Namespace: 'AWS/AppSync',
+                },
+                Period: 3600,
+                Stat: 'Sum',
+              },
+              ReturnData: false,
+            },
+          ],
+          Threshold: 0.8559999999999999,
+        }),
+      );
+    });
+
+    it('constructs an alarm for the 5.00% of 30 days budget burned in 30 minutes window', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Alarm', {
+          ComparisonOperator: 'LessThanOrEqualToThreshold',
+          EvaluationPeriods: 1,
+          AlarmName: 'My AppSync API Availability <= 0.99 - 5.00% of 30 days budget burned in 30 minutes',
+          DatapointsToAlarm: 1,
+          Metrics: [
+            {
+              Expression: '(requests - errors)/requests',
+              Id: 'expr_1',
+              Label: 'Availability',
+            },
+            {
+              Id: 'requests',
+              Label: 'Requests',
+              MetricStat: {
+                Metric: {
+                  Dimensions: [
+                    {
+                      Name: 'GraphQLAPIId',
+                      Value: 'myApiId',
+                    },
+                  ],
+                  MetricName: '5XXError',
+                  Namespace: 'AWS/AppSync',
+                },
+                Period: 1800,
+                Stat: 'SampleCount',
+              },
+              ReturnData: false,
+            },
+            {
+              Id: 'errors',
+              Label: 'Error rate',
+              MetricStat: {
+                Metric: {
+                  Dimensions: [
+                    {
+                      Name: 'GraphQLAPIId',
+                      Value: 'myApiId',
+                    },
+                  ],
+                  MetricName: '5XXError',
+                  Namespace: 'AWS/AppSync',
+                },
+                Period: 1800,
+                Stat: 'Sum',
+              },
+              ReturnData: false,
+            },
+          ],
+          Threshold: 0.94,
+        }),
+      );
+    });
+
+    it('constructs an alarm for the 5.00% of 30 days budget burned in 6 hours window', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Alarm', {
+          ComparisonOperator: 'LessThanOrEqualToThreshold',
+          EvaluationPeriods: 1,
+          AlarmName: 'My AppSync API Availability <= 0.99 - 5.00% of 30 days budget burned in 6 hours',
+          DatapointsToAlarm: 1,
+          Metrics: [
+            {
+              Expression: '(requests - errors)/requests',
+              Id: 'expr_1',
+              Label: 'Availability',
+            },
+            {
+              Id: 'requests',
+              Label: 'Requests',
+              MetricStat: {
+                Metric: {
+                  Dimensions: [
+                    {
+                      Name: 'GraphQLAPIId',
+                      Value: 'myApiId',
+                    },
+                  ],
+                  MetricName: '5XXError',
+                  Namespace: 'AWS/AppSync',
+                },
+                Period: 21600,
+                Stat: 'SampleCount',
+              },
+              ReturnData: false,
+            },
+            {
+              Id: 'errors',
+              Label: 'Error rate',
+              MetricStat: {
+                Metric: {
+                  Dimensions: [
+                    {
+                      Name: 'GraphQLAPIId',
+                      Value: 'myApiId',
+                    },
+                  ],
+                  MetricName: '5XXError',
+                  Namespace: 'AWS/AppSync',
+                },
+                Period: 21600,
+                Stat: 'Sum',
+              },
+              ReturnData: false,
+            },
+          ],
+          Threshold: 0.94,
+        }),
+      );
+    });
+
+    it('constructs an alarm for the 10.00% of 30 days budget burned in 6 hours window', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Alarm', {
+          ComparisonOperator: 'LessThanOrEqualToThreshold',
+          EvaluationPeriods: 1,
+          AlarmName: 'My AppSync API Availability <= 0.99 - 10.00% of 30 days budget burned in 6 hours',
+          DatapointsToAlarm: 1,
+          Metrics: [
+            {
+              Expression: '(requests - errors)/requests',
+              Id: 'expr_1',
+              Label: 'Availability',
+            },
+            {
+              Id: 'requests',
+              Label: 'Requests',
+              MetricStat: {
+                Metric: {
+                  Dimensions: [
+                    {
+                      Name: 'GraphQLAPIId',
+                      Value: 'myApiId',
+                    },
+                  ],
+                  MetricName: '5XXError',
+                  Namespace: 'AWS/AppSync',
+                },
+                Period: 21600,
+                Stat: 'SampleCount',
+              },
+              ReturnData: false,
+            },
+            {
+              Id: 'errors',
+              Label: 'Error rate',
+              MetricStat: {
+                Metric: {
+                  Dimensions: [
+                    {
+                      Name: 'GraphQLAPIId',
+                      Value: 'myApiId',
+                    },
+                  ],
+                  MetricName: '5XXError',
+                  Namespace: 'AWS/AppSync',
+                },
+                Period: 21600,
+                Stat: 'Sum',
+              },
+              ReturnData: false,
+            },
+          ],
+          Threshold: 0.99,
+        }),
+      );
+    });
+
+    it('constructs an alarm for the 10.00% of 30 days budget burned in 1 day window', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Alarm', {
+          ComparisonOperator: 'LessThanOrEqualToThreshold',
+          EvaluationPeriods: 1,
+          AlarmName: 'My AppSync API Availability <= 0.99 - 10.00% of 30 days budget burned in 1 day',
+          DatapointsToAlarm: 1,
+          Metrics: [
+            {
+              Expression: '(requests - errors)/requests',
+              Id: 'expr_1',
+              Label: 'Availability',
+            },
+            {
+              Id: 'requests',
+              Label: 'Requests',
+              MetricStat: {
+                Metric: {
+                  Dimensions: [
+                    {
+                      Name: 'GraphQLAPIId',
+                      Value: 'myApiId',
+                    },
+                  ],
+                  MetricName: '5XXError',
+                  Namespace: 'AWS/AppSync',
+                },
+                Period: 86400,
+                Stat: 'SampleCount',
+              },
+              ReturnData: false,
+            },
+            {
+              Id: 'errors',
+              Label: 'Error rate',
+              MetricStat: {
+                Metric: {
+                  Dimensions: [
+                    {
+                      Name: 'GraphQLAPIId',
+                      Value: 'myApiId',
+                    },
+                  ],
+                  MetricName: '5XXError',
+                  Namespace: 'AWS/AppSync',
+                },
+                Period: 86400,
+                Stat: 'Sum',
+              },
+              ReturnData: false,
+            },
+          ],
+          Threshold: 0.99,
+        }),
+      );
+    });
+
+    it('constructs a Low severity parent alarm that messages the Low severity SNS topic', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
+          AlarmName: 'My AppSync API Availability <= 0.99 (Low Severity)',
+          AlarmRule: {
+            'Fn::Join': [
+              '',
+              [
+                '(ALARM("',
+                {
+                  Ref: 'TestAlarmsMyAppSyncAPIAvailability0991000of30daysbudgetburnedin6hours9CB4A1EB',
+                },
+                '") AND ALARM("',
+                {
+                  Ref: 'TestAlarmsMyAppSyncAPIAvailability0991000of30daysbudgetburnedin1day6B7C8850',
+                },
+                '"))',
+              ],
+            ],
+          },
+          AlarmActions: [
+            {
+              Ref: 'LowSeverityTopic4780BF62',
+            },
+          ],
+          AlarmDescription:
+            'Service is at risk of exceeding its error budget. Please use the links below to troubleshoot the problem:\n\nDashboard: dashboardLink\nRun book: runbookLink\n',
+        }),
+      );
+    });
+
+    it('constructs a High severity parent alarm that messages the High severity SNS topic', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
+          AlarmName: 'My AppSync API Availability <= 0.99 (High Severity)',
+          AlarmRule: {
+            'Fn::Join': [
+              '',
+              [
+                '(ALARM("',
+                {
+                  Ref: 'TestAlarmsMyAppSyncAPIAvailability099200of30daysbudgetburnedin5minutes1F3F31B5',
+                },
+                '") AND ALARM("',
+                {
+                  Ref: 'TestAlarmsMyAppSyncAPIAvailability099200of30daysbudgetburnedin60minutes40D14724',
+                },
+                '")) OR (ALARM("',
+                {
+                  Ref: 'TestAlarmsMyAppSyncAPIAvailability099500of30daysbudgetburnedin30minutes46E7908F',
+                },
+                '") AND ALARM("',
+                {
+                  Ref: 'TestAlarmsMyAppSyncAPIAvailability099500of30daysbudgetburnedin6hours687E0054',
+                },
+                '"))',
+              ],
+            ],
+          },
+          AlarmActions: [
+            {
+              Ref: 'HighSeverityTopicC74B35F8',
+            },
+          ],
+          AlarmDescription:
+            'Service is at risk of exceeding its error budget. Please use the links below to troubleshoot the problem:\n\nDashboard: dashboardLink\nRun book: runbookLink\n',
+        }),
+      );
+    });
+
+    it('constructs a parent alarm with an alarms dashboard link when one is included', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', {
+        alarmsDashboardLink: 'alarmsDashboardLink',
+        dashboardLink: 'dashboardLink',
+        runbookLink: 'runbookLink',
+        slos,
+      });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
+          AlarmName: 'My API Availability <= 0.99 (High Severity)',
+          AlarmDescription:
+            'Service is at risk of exceeding its error budget. Please use the links below to troubleshoot the problem:\n\nDashboard: dashboardLink\nRun book: runbookLink\nAlarms Dashboard: alarmsDashboardLink\n',
+        }),
+      );
+    });
+  });
+
+  describe('ApiLatency', () => {
+    it('constructs an alarm for the 2.00% of 30 days budget burned in 5 minutes window', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Alarm', {
+          ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+          EvaluationPeriods: 1,
+          AlarmName: 'My AppSync API Latency P99 >= 2000ms - 2.00% of 30 days budget burned in 5 minutes',
+          DatapointsToAlarm: 1,
+          Dimensions: [
+            {
+              Name: 'GraphQLAPIId',
+              Value: 'myApiId',
+            },
+          ],
+          ExtendedStatistic: 'p85.60',
+          MetricName: 'Latency',
+          Namespace: 'AWS/AppSync',
+          Period: 300,
+          Threshold: 2000,
+        }),
+      );
+    });
+
+    it('constructs an alarm for the 2.00% of 30 days budget burned in 60 minutes window', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Alarm', {
+          ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+          EvaluationPeriods: 1,
+          AlarmName: 'My AppSync API Latency P99 >= 2000ms - 2.00% of 30 days budget burned in 60 minutes',
+          DatapointsToAlarm: 1,
+          Dimensions: [
+            {
+              Name: 'GraphQLAPIId',
+              Value: 'myApiId',
+            },
+          ],
+          ExtendedStatistic: 'p85.60',
+          MetricName: 'Latency',
+          Namespace: 'AWS/AppSync',
+          Period: 3600,
+          Threshold: 2000,
+        }),
+      );
+    });
+
+    it('constructs an alarm for the 5.00% of 30 days budget burned in 30 minutes window', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Alarm', {
+          ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+          EvaluationPeriods: 1,
+          AlarmName: 'My AppSync API Latency P99 >= 2000ms - 5.00% of 30 days budget burned in 30 minutes',
+          DatapointsToAlarm: 1,
+          Dimensions: [
+            {
+              Name: 'GraphQLAPIId',
+              Value: 'myApiId',
+            },
+          ],
+          ExtendedStatistic: 'p94.00',
+          MetricName: 'Latency',
+          Namespace: 'AWS/AppSync',
+          Period: 1800,
+          Threshold: 2000,
+        }),
+      );
+    });
+
+    it('constructs an alarm for the 5.00% of 30 days budget burned in 6 hours window', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Alarm', {
+          ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+          EvaluationPeriods: 1,
+          AlarmName: 'My AppSync API Latency P99 >= 2000ms - 5.00% of 30 days budget burned in 6 hours',
+          DatapointsToAlarm: 1,
+          Dimensions: [
+            {
+              Name: 'GraphQLAPIId',
+              Value: 'myApiId',
+            },
+          ],
+          ExtendedStatistic: 'p94.00',
+          MetricName: 'Latency',
+          Namespace: 'AWS/AppSync',
+          Period: 21600,
+          Threshold: 2000,
+        }),
+      );
+    });
+
+    it('constructs an alarm for the 10.00% of 30 days budget burned in 6 hours window', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Alarm', {
+          ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+          EvaluationPeriods: 1,
+          AlarmName: 'My AppSync API Latency P99 >= 2000ms - 10.00% of 30 days budget burned in 6 hours',
+          DatapointsToAlarm: 1,
+          Dimensions: [
+            {
+              Name: 'GraphQLAPIId',
+              Value: 'myApiId',
+            },
+          ],
+          ExtendedStatistic: 'p99.00',
+          MetricName: 'Latency',
+          Namespace: 'AWS/AppSync',
+          Period: 21600,
+          Threshold: 2000,
+        }),
+      );
+    });
+
+    it('constructs an alarm for the 10.00% of 30 days budget burned in 1 day window', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Alarm', {
+          ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+          EvaluationPeriods: 1,
+          AlarmName: 'My AppSync API Latency P99 >= 2000ms - 10.00% of 30 days budget burned in 1 day',
+          DatapointsToAlarm: 1,
+          Dimensions: [
+            {
+              Name: 'GraphQLAPIId',
+              Value: 'myApiId',
+            },
+          ],
+          ExtendedStatistic: 'p99.00',
+          MetricName: 'Latency',
+          Namespace: 'AWS/AppSync',
+          Period: 86400,
+          Threshold: 2000,
+        }),
+      );
+    });
+
+    it('constructs a Low severity parent alarm that messages the Low severity SNS topic', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
+          AlarmName: 'My AppSync API Latency P99 >= 2000ms (Low Severity)',
+          AlarmRule: {
+            'Fn::Join': [
+              '',
+              [
+                '(ALARM("',
+                {
+                  Ref: 'TestAlarmsMyAppSyncAPILatencyP992000ms1000of30daysbudgetburnedin6hoursE7F37285',
+                },
+                '") AND ALARM("',
+                {
+                  Ref: 'TestAlarmsMyAppSyncAPILatencyP992000ms1000of30daysbudgetburnedin1day79FC1CE0',
+                },
+                '"))',
+              ],
+            ],
+          },
+          AlarmActions: [
+            {
+              Ref: 'LowSeverityTopic4780BF62',
+            },
+          ],
+          AlarmDescription:
+            'Service is at risk of exceeding its error budget. Please use the links below to troubleshoot the problem:\n\nDashboard: dashboardLink\nRun book: runbookLink\n',
+        }),
+      );
+    });
+
+    it('constructs a High severity parent alarm that messages the High severity SNS topic', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', { dashboardLink: 'dashboardLink', runbookLink: 'runbookLink', slos });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
+          AlarmName: 'My AppSync API Latency P99 >= 2000ms (High Severity)',
+          AlarmRule: {
+            'Fn::Join': [
+              '',
+              [
+                '(ALARM("',
+                {
+                  Ref: 'TestAlarmsMyAppSyncAPILatencyP992000ms200of30daysbudgetburnedin5minutes36B030DA',
+                },
+                '") AND ALARM("',
+                {
+                  Ref: 'TestAlarmsMyAppSyncAPILatencyP992000ms200of30daysbudgetburnedin60minutes6C562D1E',
+                },
+                '")) OR (ALARM("',
+                {
+                  Ref: 'TestAlarmsMyAppSyncAPILatencyP992000ms500of30daysbudgetburnedin30minutes10771BAC',
+                },
+                '") AND ALARM("',
+                {
+                  Ref: 'TestAlarmsMyAppSyncAPILatencyP992000ms500of30daysbudgetburnedin6hoursB07C9628',
+                },
+                '"))',
+              ],
+            ],
+          },
+          AlarmActions: [
+            {
+              Ref: 'HighSeverityTopicC74B35F8',
+            },
+          ],
+          AlarmDescription:
+            'Service is at risk of exceeding its error budget. Please use the links below to troubleshoot the problem:\n\nDashboard: dashboardLink\nRun book: runbookLink\n',
+        }),
+      );
+    });
+
+    it('constructs a parent alarm with an alarms dashboard link when one is included', () => {
+      const stack = new Stack();
+      new SLOAlarms(stack, 'TestAlarms', {
+        alarmsDashboardLink: 'alarmsDashboardLink',
+        dashboardLink: 'dashboardLink',
+        runbookLink: 'runbookLink',
+        slos,
+      });
+
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::CompositeAlarm', {
+          AlarmName: 'My AppSync API Latency P99 >= 2000ms (High Severity)',
           AlarmDescription:
             'Service is at risk of exceeding its error budget. Please use the links below to troubleshoot the problem:\n\nDashboard: dashboardLink\nRun book: runbookLink\nAlarms Dashboard: alarmsDashboardLink\n',
         }),

--- a/tests/slos/appsync-availability-metric.test.ts
+++ b/tests/slos/appsync-availability-metric.test.ts
@@ -1,0 +1,54 @@
+import { AppSyncAvailabilityMetric } from '../../src/slos/appsync-availability-metric';
+import { Windows } from '../../src/slos/windows';
+import { Duration } from '@aws-cdk/core';
+import { Metric } from '@aws-cdk/aws-cloudwatch';
+
+describe('AppSyncAvailabilityMetric', () => {
+  test('uses sum for the statistic for the error metric', () => {
+    const expression = new AppSyncAvailabilityMetric({ apiId: 'apiId', sloWindow: Windows.twoPercentLong });
+    const typedMetric = expression.usingMetrics.errors as Metric;
+    expect(typedMetric.statistic).toEqual('Sum');
+  });
+
+  test('uses the AWS/AppSync namespace for all metrics', () => {
+    const expression = new AppSyncAvailabilityMetric({ apiId: 'apiId', sloWindow: Windows.twoPercentLong });
+    Object.keys(expression.usingMetrics).forEach(metric => {
+      const typedMetric = expression.usingMetrics[metric] as Metric;
+      expect(typedMetric.namespace).toEqual('AWS/AppSync');
+    });
+  });
+
+  test('uses sample count of errors as the requests', () => {
+    const expression = new AppSyncAvailabilityMetric({ apiId: 'apiId', sloWindow: Windows.twoPercentLong });
+    const typedMetric = expression.usingMetrics.requests as Metric;
+    expect(typedMetric.metricName).toEqual('5XXError');
+    expect(typedMetric.statistic).toEqual('SampleCount');
+  });
+
+  test('uses 5xx as errors', () => {
+    const expression = new AppSyncAvailabilityMetric({ apiId: 'apiId', sloWindow: Windows.twoPercentLong });
+    const typedMetric = expression.usingMetrics.errors as Metric;
+    expect(typedMetric.metricName).toEqual('5XXError');
+  });
+
+  test('uses fraction of successful requests as the expression', () => {
+    const expression = new AppSyncAvailabilityMetric({ apiId: 'apiId', sloWindow: Windows.twoPercentLong });
+    expect(expression.expression).toEqual('(requests - errors)/requests');
+  });
+
+  test('uses the api id for dimensions in all metrics', () => {
+    const expression = new AppSyncAvailabilityMetric({ apiId: 'apiId', sloWindow: Windows.twoPercentLong });
+    Object.keys(expression.usingMetrics).forEach(metric => {
+      const typedMetric = expression.usingMetrics[metric] as Metric;
+      expect(typedMetric.dimensions).toEqual({ GraphQLAPIId: 'apiId' });
+    });
+  });
+
+  test('uses the alert window size for the period in all metrics', () => {
+    const expression = new AppSyncAvailabilityMetric({ apiId: 'apiId', sloWindow: Windows.twoPercentLong });
+    Object.keys(expression.usingMetrics).forEach(metric => {
+      const typedMetric = expression.usingMetrics[metric] as Metric;
+      expect(typedMetric.period).toEqual(Duration.hours(1));
+    });
+  });
+});

--- a/tests/slos/appsync-availability-widget.test.ts
+++ b/tests/slos/appsync-availability-widget.test.ts
@@ -1,0 +1,35 @@
+import { AppSyncAvailabilityWidget } from '../../src/slos/appsync-availability-widget';
+import { AppSyncAvailabilityMetric } from '../../src/slos/appsync-availability-metric';
+import { AvailabilityWidget } from '../../src/slos/availability-widget';
+import { Windows } from '../../src/slos/windows';
+import { mocked } from 'ts-jest/dist/util/testing';
+
+const mockInstance = { foo: 'bar' };
+
+jest.mock('../../src/slos/appsync-availability-metric', () => {
+  return {
+    AppSyncAvailabilityMetric: jest.fn().mockImplementation(() => {
+      return mockInstance;
+    }),
+  };
+});
+jest.mock('../../src/slos/availability-widget');
+
+describe('AppSyncAvailabilityWidget', () => {
+  const MockedAppSyncAvailabilityMetric = mocked(AppSyncAvailabilityMetric, true);
+  const MockedAvailabilityWidget = mocked(AvailabilityWidget, true);
+
+  beforeEach(() => {
+    MockedAppSyncAvailabilityMetric.mockClear();
+    MockedAvailabilityWidget.mockClear();
+  });
+
+  it('uses the AppSyncAvailabilityMetric class as its availability metric when constructing an AvailabilityWidget', () => {
+    new AppSyncAvailabilityWidget({
+      apiId: 'apiId',
+      sloThreshold: 0.99,
+      sloWindow: Windows.twoPercentLong,
+    });
+    expect(MockedAvailabilityWidget).toHaveBeenCalledWith(expect.objectContaining({ availability: mockInstance }));
+  });
+});

--- a/tests/slos/appsync-latency-metric.test.ts
+++ b/tests/slos/appsync-latency-metric.test.ts
@@ -1,0 +1,66 @@
+import { AppSyncLatencyMetric } from '../../src/slos/appsync-latency-metric';
+import { Windows } from '../../src/slos/windows';
+import { Duration } from '@aws-cdk/core';
+
+describe('AppSyncLatencyMetric', () => {
+  test('uses the window burn rate threshold for the statistic and puts the statistic in its label', () => {
+    const expectations = [
+      {
+        sloThreshold: 0.999,
+        windows: [
+          { window: Windows.twoPercentLong, expectedStatistic: 'p98.56' },
+          { window: Windows.fivePercentLong, expectedStatistic: 'p99.40' },
+          { window: Windows.tenPercentLong, expectedStatistic: 'p99.90' },
+        ],
+      },
+      {
+        sloThreshold: 0.95,
+        windows: [
+          { window: Windows.twoPercentLong, expectedStatistic: 'p28.00' },
+          { window: Windows.fivePercentLong, expectedStatistic: 'p70.00' },
+          { window: Windows.tenPercentLong, expectedStatistic: 'p95.00' },
+        ],
+      },
+      {
+        sloThreshold: 0.5,
+        windows: [{ window: Windows.tenPercentLong, expectedStatistic: 'p50.00' }],
+      },
+    ];
+    expectations.forEach(expectation => {
+      expectation.windows.forEach(window => {
+        const metric = new AppSyncLatencyMetric({
+          apiId: 'apiId',
+          sloThreshold: expectation.sloThreshold,
+          sloWindow: window.window,
+        });
+        expect(metric.statistic).toEqual(window.expectedStatistic);
+        expect(metric.label).toEqual(`Latency ${window.expectedStatistic}`);
+      });
+    });
+  });
+
+  test('uses the AWS/AppSync namespace', () => {
+    const metric = new AppSyncLatencyMetric({ apiId: 'apiId', sloThreshold: 0.999, sloWindow: Windows.twoPercentLong });
+    expect(metric.namespace).toEqual('AWS/AppSync');
+  });
+
+  test('uses total latency of the client request', () => {
+    const metric = new AppSyncLatencyMetric({ apiId: 'apiId', sloThreshold: 0.999, sloWindow: Windows.twoPercentLong });
+    expect(metric.metricName).toEqual('Latency');
+  });
+
+  test('uses the api name for dimensions', () => {
+    const metric = new AppSyncLatencyMetric({ apiId: 'apiId', sloThreshold: 0.999, sloWindow: Windows.twoPercentLong });
+    expect(metric.dimensions).toEqual({ GraphQLAPIId: 'apiId' });
+  });
+
+  test('uses the alert window size for the period', () => {
+    const metric = new AppSyncLatencyMetric({ apiId: 'apiId', sloThreshold: 0.999, sloWindow: Windows.twoPercentLong });
+    expect(metric.period).toEqual(Duration.hours(1));
+  });
+
+  test('uses p0 for the statistic when too small a window is used for the threshold', () => {
+    const metric = new AppSyncLatencyMetric({ apiId: 'apiId', sloThreshold: 0.5, sloWindow: Windows.twoPercentLong });
+    expect(metric.statistic).toEqual('p0.00');
+  });
+});

--- a/tests/slos/appsync-latency-widget.test.ts
+++ b/tests/slos/appsync-latency-widget.test.ts
@@ -1,0 +1,36 @@
+import { AppSyncLatencyWidget } from '../../src/slos/appsync-latency-widget';
+import { AppSyncLatencyMetric } from '../../src/slos/appsync-latency-metric';
+import { LatencyWidget } from '../../src/slos/latency-widget';
+import { Windows } from '../../src/slos/windows';
+import { mocked } from 'ts-jest/dist/util/testing';
+
+const mockInstance = { foo: 'bar' };
+
+jest.mock('../../src/slos/appsync-latency-metric', () => {
+  return {
+    AppSyncLatencyMetric: jest.fn().mockImplementation(() => {
+      return mockInstance;
+    }),
+  };
+});
+jest.mock('../../src/slos/latency-widget');
+
+describe('AppSyncLatencyWidget', () => {
+  const MockedAppSyncLatencyMetric = mocked(AppSyncLatencyMetric, true);
+  const MockedLatencyWidget = mocked(LatencyWidget, true);
+
+  beforeEach(() => {
+    MockedAppSyncLatencyMetric.mockClear();
+    MockedLatencyWidget.mockClear();
+  });
+
+  it('uses the AppSyncLatencyMetric class as its latency metric when constructing an LatencyWidget', () => {
+    new AppSyncLatencyWidget({
+      apiId: 'apiId',
+      sloThreshold: 0.99,
+      latencyThreshold: 200,
+      sloWindow: Windows.twoPercentLong,
+    });
+    expect(MockedLatencyWidget).toHaveBeenCalledWith(expect.objectContaining({ latency: mockInstance }));
+  });
+});

--- a/tests/slos/performance-dashboard.test.ts
+++ b/tests/slos/performance-dashboard.test.ts
@@ -315,6 +315,98 @@ describe('SLOPerformanceDashboard', () => {
     });
   });
 
+  describe('AppSyncAvailability', () => {
+    const slos = [{ type: 'AppSyncAvailability', apiId: 'myApiId', title: 'My AppSync API', sloThreshold: 0.99 }];
+
+    it('constructs a dashboard with a 30 day window widget', () => {
+      const stack = new Stack();
+      new SLOPerformanceDashboard(stack, 'TestPerformanceDashboard', {
+        slos,
+        dashboardName: 'TestPerformanceDashboard',
+      });
+
+      const dashBody = Capture.anyType();
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Dashboard', {
+          DashboardBody: dashBody.capture(),
+          DashboardName: 'TestPerformanceDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My AppSync API - Availability`,
+                metrics: [
+                  [{ label: 'Availability', expression: '(requests - errors)/requests' }],
+                  [
+                    'AWS/AppSync',
+                    '5XXError',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Requests', period: 2592000, stat: 'SampleCount', visible: false, id: 'requests' },
+                  ],
+                  [
+                    'AWS/AppSync',
+                    '5XXError',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Error rate', period: 2592000, stat: 'Sum', visible: false, id: 'errors' },
+                  ],
+                ],
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+  });
+
+  describe('AppSyncLatency', () => {
+    const slos = [
+      { type: 'AppSyncLatency', apiId: 'myApiId', title: 'My AppSync API', sloThreshold: 0.99, latencyThreshold: 2000 },
+    ];
+
+    it('constructs a dashboard with a 30 day window widget', () => {
+      const stack = new Stack();
+      new SLOPerformanceDashboard(stack, 'TestPerformanceDashboard', {
+        slos,
+        dashboardName: 'TestPerformanceDashboard',
+      });
+
+      const dashBody = Capture.anyType();
+      cdkExpect(stack).to(
+        haveResourceLike('AWS::CloudWatch::Dashboard', {
+          DashboardBody: dashBody.capture(),
+          DashboardName: 'TestPerformanceDashboard',
+        }),
+      );
+      const dashObj = JSON.parse(collapseJoin(dashBody.capturedValue));
+      expect(dashObj).toEqual(
+        expect.objectContaining({
+          widgets: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                title: `My AppSync API - Latency 2000ms`,
+                metrics: [
+                  [
+                    'AWS/AppSync',
+                    'Latency',
+                    'GraphQLAPIId',
+                    'myApiId',
+                    { label: 'Latency p99.00', period: 2592000, stat: 'p99.00' },
+                  ],
+                ],
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+  });
+
   describe('CustomAvailability', () => {
     const slos = [
       {


### PR DESCRIPTION
Adds AppSyncAvailability and AppSyncLatency as valid types for creating
SLO alarms and dashboards for an AppSync API.