### PR TITLE
build: fix subpackage error downstream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "@ndlib/ndlib-cdk",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ndlib/ndlib-cdk",
-      "version": "1.8.0",
-      "hasInstallScript": true,
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/aws-apigateway": "^1.91.0",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "postinstall": "subpkg install",
     "test": "jest --config jestconfig.json",
     "coverage": "jest --config jestconfig.json --coverage",
-    "build": "tsc && ./copy-lambda-files.sh",
+    "build": "subpkg install && tsc && ./copy-lambda-files.sh",
     "format": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
     "lint": "eslint '*/**/*.{js,ts,tsx}'",
     "generate-changelog": "github-changes -n ${npm_package_version} -o ndlib -r ndlib-cdk --only-pulls --use-commit-body",


### PR DESCRIPTION
`postinstall` is run by consumers when installing ndlib-cdk. Subpackage is a dev dependency so it won't work there (and it doesn't need to, since they should have already been packaged up in the published build.)

This fixes the issue by moving it to `build` (which is run by `prepare`)