### PR TITLE
feat(transclusion-lambda): change originBucket param to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,8 @@ import { Certificate } from '@aws-cdk/aws-certificatemanager'
 import { StaticHost, TransclusionLambda } from '@ndlib/ndlib-cdk'
 
 const stack = new cdk.Stack()
-const siteBucket = new Bucket(stack, 'Bucket')
 const transclusionLambda = new TransclusionLambda(stack, 'Transclusion', {
   isDefaultBehavior: true,
-  originBucket: siteBucket,
 })
 const host = new StaticHost(stack, 'MyStaticHost', {
   hostnamePrefix: 'my-site',

--- a/src/static-host/static-host.ts
+++ b/src/static-host/static-host.ts
@@ -86,6 +86,16 @@ export class StaticHost extends cdk.Construct {
   public readonly hostname: string
 
   /**
+   * Parameter in SSM which will store the name of the site content s3 bucket.
+   */
+  public readonly bucketNameParam: StringParameter
+
+  /**
+   * Parameter in SSM which will store the id of the cloudfront distribution.
+   */
+  public readonly distributionIdParam: StringParameter
+
+  /**
    * Props passed to constructor. Used for validation.
    */
   private readonly inProps: IStaticHostProps
@@ -210,13 +220,13 @@ export class StaticHost extends cdk.Construct {
       })
     }
 
-    new StringParameter(this, 'BucketParameter', {
+    this.bucketNameParam = new StringParameter(this, 'BucketParameter', {
       parameterName: `/all/stacks/${stack.stackName}/site-bucket-name`,
       description: 'Bucket where the stack website deploys to.',
       stringValue: this.bucket.bucketName,
     })
 
-    new StringParameter(this, 'DistributionParameter', {
+    this.distributionIdParam = new StringParameter(this, 'DistributionParameter', {
       parameterName: `/all/stacks/${stack.stackName}/distribution-id`,
       description: 'ID of the CloudFront distribution.',
       stringValue: this.cloudfront.distributionId,


### PR DESCRIPTION
Edge Lambdas have to be defined before a CloudFront in order to add behaviors. Since StaticHost creates both the bucket and the cloudfront, that means you can't pass a reference to the bucket when creating the lambda. I made this param optional and added a function to add the permissions after the fact, which would resolve this situation.

The StaticHost stack will grant edge lambdas permissions to the bucket anyway, so it won't be necessary to call this when using the two together... But it could prove useful if using the edge lambda in another context nonetheless.

I also added construct properties for the parameters that StaticHost outputs. This way you can reference them to get their names instead of hardcoding and relying on them matching up.